### PR TITLE
SUIT-17-3

### DIFF
--- a/SUITE/src/hook/useForm.tsx
+++ b/SUITE/src/hook/useForm.tsx
@@ -18,10 +18,9 @@ const useForm = () => {
       ...values,
       [name]: text,
     });
-
     // 유효성 검사 수행
     if (name === 'username') {
-      if (!text) {
+      if (!text || text == '') {
         setErrors({
           ...errors,
           [name]: '이메일을 입력해주세요.',
@@ -34,7 +33,7 @@ const useForm = () => {
       } else {
         setErrors({
           ...errors,
-          [name]: undefined,
+          [name]: '',
         });
       }
     } else if (name === 'password') {
@@ -51,7 +50,7 @@ const useForm = () => {
       } else {
         setErrors({
           ...errors,
-          [name]: undefined,
+          [name]: '',
         });
       }
     }

--- a/SUITE/src/screens/AuthScreen/Login.tsx
+++ b/SUITE/src/screens/AuthScreen/Login.tsx
@@ -21,6 +21,12 @@ const Login = () => {
     }
     if (login.errors.password) {
       setValidatePW(false);
+    }
+    if (login.getTextInputProps('password').value == '') {
+      setValidatePW(false);
+    }
+    if (login.getTextInputProps('username').value == '') {
+      setValidateEmail(false);
     } else {
       console.log('로그인 성공'); //로그인 API 연동
       setValidateEmail(true);

--- a/SUITE/src/screens/AuthScreen/SignUp/EmailAuthentication.tsx
+++ b/SUITE/src/screens/AuthScreen/SignUp/EmailAuthentication.tsx
@@ -1,10 +1,91 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import React, { useEffect, useState } from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import useForm from '../../../hook/useForm';
+import mainPageStyleSheet from '../../../style/style';
+import { RootStackNavigationProp } from '../Login';
+import Icon from 'react-native-vector-icons/Ionicons';
+import InputField from '../../../components/presents/InputField';
 
 const EmailAuthentication = () => {
+  const navigation = useNavigation<RootStackNavigationProp>();
+  const emailAuthentication = useForm();
+  const [passwordConfirmation, setPasswordConfirmation] = useState('');
+  const [isButtonDisabled, setIsButtonDisabled] = useState(true);
+
+  const handlePasswordConfirmationChange = (text: string) => {
+    setPasswordConfirmation(text);
+  };
+  const validatePassword = () => {
+    return emailAuthentication.getTextInputProps('password').value === passwordConfirmation;
+  };
+
+  const handleButtonPress = () => {
+    navigation.navigate('UserInformation'); //로그인 API 연동
+  };
+
+  useEffect(() => {
+    if (emailAuthentication.errors.username == '' && emailAuthentication.errors.password == '' && validatePassword()) {
+      setIsButtonDisabled(false);
+    } else {
+      setIsButtonDisabled(true);
+    }
+  }, [emailAuthentication.errors.username, emailAuthentication.errors.password, validatePassword]);
+
   return (
-    <View>
-      <Text>EmailAuthentication page</Text>
+    <View style={mainPageStyleSheet.categoryPageContainer}>
+      <View style={mainPageStyleSheet.underStatusBar}>
+        <TouchableOpacity
+          style={mainPageStyleSheet.pageBackIcon}
+          onPress={() => {
+            navigation.navigate('TermOfUse');
+          }}
+        >
+          <Icon name="chevron-back" size={24} color={'#000000'} />
+        </TouchableOpacity>
+        <Text style={mainPageStyleSheet.SignUpText}>이메일 인증</Text>
+      </View>
+      <View style={mainPageStyleSheet.emailAuthenticationContainer}>
+        <Text style={mainPageStyleSheet.idpwtext}>이메일</Text>
+        <InputField
+          autoFocus
+          placeholder=" 이메일을 입력해주세요"
+          {...emailAuthentication.getTextInputProps('username')}
+          touched={emailAuthentication.touched.username}
+        />
+        <Text>{<Text style={mainPageStyleSheet.idPwInputErrorText}>{emailAuthentication.errors.username}</Text>}</Text>
+        <Text style={mainPageStyleSheet.idpwtext}>비밀번호</Text>
+        <InputField
+          style={mainPageStyleSheet.idpwInputBox}
+          placeholder=" 비밀번호를 입력해주세요"
+          {...emailAuthentication.getTextInputProps('password')}
+          touched={emailAuthentication.touched.password}
+          secureTextEntry
+        />
+        <Text>{<Text style={mainPageStyleSheet.idPwInputErrorText}>{emailAuthentication.errors.password}</Text>}</Text>
+        <Text style={mainPageStyleSheet.idpwtext}>비밀번호 재입력</Text>
+        <InputField
+          style={mainPageStyleSheet.idpwInputBox}
+          placeholder=" 비밀번호를 다시 입력해주세요"
+          onChangeText={handlePasswordConfirmationChange}
+          touched={emailAuthentication.touched.password}
+          secureTextEntry
+        />
+        {!validatePassword() && (
+          <Text style={mainPageStyleSheet.idPwInputErrorText}>비밀번호가 일치하지 않습니다.</Text>
+        )}
+      </View>
+      <View style={mainPageStyleSheet.SignUpNextBtnContainer}>
+        <TouchableOpacity
+          style={[mainPageStyleSheet.SignUpNextBtnBtn, isButtonDisabled && mainPageStyleSheet.disabledSignUpNextBtnBtn]}
+          disabled={isButtonDisabled}
+          onPress={() => {
+            handleButtonPress();
+          }}
+        >
+          <Text style={mainPageStyleSheet.SignUpNextBtnText}>다음</Text>
+        </TouchableOpacity>
+      </View>
     </View>
   );
 };

--- a/SUITE/src/screens/AuthScreen/SignUp/TermOfUse.tsx
+++ b/SUITE/src/screens/AuthScreen/SignUp/TermOfUse.tsx
@@ -81,7 +81,7 @@ const TermOfUse = () => {
     if (!ageChecked || !termsChecked || !privacyChecked) {
       setCheckedBtn(false);
     } else {
-      navigation.navigate('UserInformation');
+      navigation.navigate('EmailAuthentication');
     }
   };
   return (
@@ -153,9 +153,9 @@ const TermOfUse = () => {
           />
         </View>
       </View>
-      <View style={mainPageStyleSheet.endTermOfUseContainer}>
-        <TouchableOpacity style={mainPageStyleSheet.endTermOfUseBtn} onPress={handleNextPage}>
-          <Text style={mainPageStyleSheet.endTermOfUseBtnText}>SUITE 시작하기</Text>
+      <View style={mainPageStyleSheet.SignUpNextBtnContainer}>
+        <TouchableOpacity style={mainPageStyleSheet.SignUpNextBtnBtn} onPress={handleNextPage}>
+          <Text style={mainPageStyleSheet.SignUpNextBtnText}>SUITE 시작하기</Text>
         </TouchableOpacity>
       </View>
     </View>

--- a/SUITE/src/screens/AuthScreen/SignUp/UserInformation.tsx
+++ b/SUITE/src/screens/AuthScreen/SignUp/UserInformation.tsx
@@ -1,10 +1,27 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
+import mainPageStyleSheet from '../../../style/style';
+import Icon from 'react-native-vector-icons/Ionicons';
+import { useNavigation } from '@react-navigation/core';
+import { RootStackNavigationProp } from '../Login';
+import useForm from '../../../hook/useForm';
 
 const UserInformation = () => {
+  const navigation = useNavigation<RootStackNavigationProp>();
+  const signUp = useForm();
   return (
-    <View>
-      <Text>UserInformation page</Text>
+    <View style={mainPageStyleSheet.categoryPageContainer}>
+      <View style={mainPageStyleSheet.underStatusBar}>
+        <TouchableOpacity
+          style={mainPageStyleSheet.pageBackIcon}
+          onPress={() => {
+            navigation.navigate('TermOfUse');
+          }}
+        >
+          <Icon name="chevron-back" size={24} color={'#000000'} />
+        </TouchableOpacity>
+        <Text style={mainPageStyleSheet.SignUpText}>회원가입</Text>
+      </View>
     </View>
   );
 };

--- a/SUITE/src/style/style.js
+++ b/SUITE/src/style/style.js
@@ -320,6 +320,8 @@ const mainPageStyleSheet = StyleSheet.create({
   underStatusBar: {
     width: Width,
     height: heightPercentage(48),
+    flexDirection: 'row',
+    alignItems: 'center',
   },
   pageBackIcon: {
     marginTop: 12,
@@ -379,7 +381,7 @@ const mainPageStyleSheet = StyleSheet.create({
     justifyContent: 'center',
     paddingRight: 15,
   },
-  endTermOfUseContainer: {
+  SignUpNextBtnContainer: {
     position: 'absolute',
     bottom: 0,
     left: 0,
@@ -390,7 +392,7 @@ const mainPageStyleSheet = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  endTermOfUseBtn: {
+  SignUpNextBtnBtn: {
     width: widthPercentage(320),
     height: heightPercentage(50),
     backgroundColor: '#050953',
@@ -398,11 +400,33 @@ const mainPageStyleSheet = StyleSheet.create({
     alignItems: 'center',
     borderRadius: 24,
   },
-  endTermOfUseBtnText: {
+  disabledSignUpNextBtnBtn: {
+    width: widthPercentage(320),
+    height: heightPercentage(50),
+    backgroundColor: '#E8E8E8',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 24,
+  },
+  SignUpNextBtnText: {
     fontSize: 16,
     color: '#FFFFFF',
     fontWeight: 'bold',
     fontFamily: 'PretendardVariable',
+  },
+  SignUpText: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    textAlign: 'center',
+    fontSize: 16,
+    color: '#000000',
+    fontFamily: 'PretendardVariable',
+  },
+  emailAuthenticationContainer: {
+    marginTop: heightPercentage(40),
+    marginLeft: widthPercentage(24),
+    marginRight: widthPercentage(24),
   },
 });
 


### PR DESCRIPTION
### 🗓️ PR 날짜 🗓️
2023/08/01


### 🧐 구현 방법 🧐
* 약관 동의 후 이메일 인증을 위해 이메일과 비밀번호 입력하는 페이지 제작했습니다.
* 이메일, 비밀번호, 비밀번호 확인 모두 유효성 검사에서 통과하지 않으면 다음으로 넘어가는 버튼이 disabled 되도록 해놨습니다.
* 비밀번호 확인 유효성검사까지 모두 통과한다면 그때 버튼을 눌릴수 있게 해놨습니다.
* 이 다음에는 이메일 인증 코드를 입력할 수 있도록 하는 페이지로 navigation할 예정입니다.

### 📸 UI 명세서 사진 📸


https://github.com/SWM-TheDreaming/SUITE_FRONT/assets/43203911/4b701ab0-0ec2-4a93-87d7-cbee0163970a




### 실제 코드
