### PR TITLE
SUIT-15-3

### DIFF
--- a/SUITE/android/app/src/main/AndroidManifest.xml
+++ b/SUITE/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package = "com.suite">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA"/>
@@ -8,7 +9,7 @@
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
-      android:allowBackup="false"
+      android:allowBackup="true"
       android:theme="@style/AppTheme"
       android:requestLegacyExternalStorage="true"
       >
@@ -24,5 +25,14 @@
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
       </activity>
+       <activity android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+      android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:host="oauth" android:scheme="kakao7b0919ce4432e621c97e3df08968dd96" />
+      </intent-filter>
+    </activity>
     </application>
 </manifest>

--- a/SUITE/android/app/src/main/res/values/strings.xml
+++ b/SUITE/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">SUITE</string>
+    <string name="kakao_app_key">7b0919ce4432e621c97e3df08968dd96</string>
 </resources>

--- a/SUITE/android/build.gradle
+++ b/SUITE/android/build.gradle
@@ -13,6 +13,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://devrepo.kakao.com/nexus/content/groups/public/' }
     }
     dependencies {
         classpath("com.android.tools.build:gradle")

--- a/SUITE/ios/Podfile.lock
+++ b/SUITE/ios/Podfile.lock
@@ -1,4 +1,5 @@
 PODS:
+  - Alamofire (5.7.1)
   - BEMCheckBox (1.4.1)
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
@@ -74,6 +75,22 @@ PODS:
   - hermes-engine (0.72.3):
     - hermes-engine/Pre-built (= 0.72.3)
   - hermes-engine/Pre-built (0.72.3)
+  - kakao-login (5.3.0):
+    - KakaoSDKAuth (= 2.11.1)
+    - KakaoSDKCommon (= 2.11.1)
+    - KakaoSDKUser (= 2.11.1)
+    - React
+  - KakaoSDKAuth (2.11.1):
+    - KakaoSDKCommon (= 2.11.1)
+  - KakaoSDKCommon (2.11.1):
+    - KakaoSDKCommon/Common (= 2.11.1)
+    - KakaoSDKCommon/Network (= 2.11.1)
+  - KakaoSDKCommon/Common (2.11.1)
+  - KakaoSDKCommon/Network (2.11.1):
+    - Alamofire (~> 5.1)
+    - KakaoSDKCommon/Common (= 2.11.1)
+  - KakaoSDKUser (2.11.1):
+    - KakaoSDKAuth (= 2.11.1)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.07.22.00):
@@ -546,6 +563,7 @@ DEPENDENCIES:
   - FlipperKit/SKIOSNetworkPlugin (= 0.182.0)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
+  - "kakao-login (from `../node_modules/@react-native-seoul/kakao-login`)"
   - libevent (~> 2.1.12)
   - OpenSSL-Universal (= 1.1.1100)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
@@ -595,6 +613,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - Alamofire
     - BEMCheckBox
     - CocoaAsyncSocket
     - Flipper
@@ -606,6 +625,9 @@ SPEC REPOS:
     - Flipper-PeerTalk
     - FlipperKit
     - fmt
+    - KakaoSDKAuth
+    - KakaoSDKCommon
+    - KakaoSDKUser
     - libevent
     - OpenSSL-Universal
     - SocketRocket
@@ -626,6 +648,8 @@ EXTERNAL SOURCES:
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
     :tag: hermes-2023-03-20-RNv0.72.0-49794cfc7c81fb8f69fd60c3bbf85a7480cc5a77
+  kakao-login:
+    :path: "../node_modules/@react-native-seoul/kakao-login"
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -712,6 +736,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
+  Alamofire: 0123a34370cb170936ae79a8df46cc62b2edeb88
   BEMCheckBox: 5ba6e37ade3d3657b36caecc35c8b75c6c2b1a4e
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
@@ -729,6 +754,10 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 10fbd3f62405c41ea07e71973ea61e1878d07322
+  kakao-login: 3d7afeb8d49d4fa9a3ee579edb1b68c65bf20dac
+  KakaoSDKAuth: bb2dfa7be30daa8403c9cfc8001aa6fde7a5b779
+  KakaoSDKCommon: 555e1bb46595b842ded01cf7888cc17bbae4e113
+  KakaoSDKUser: 08c0a4f40bebdebdf948a9e3d0e44ed5c2754f99
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1

--- a/SUITE/ios/SUITE.xcodeproj/project.pbxproj
+++ b/SUITE/ios/SUITE.xcodeproj/project.pbxproj
@@ -544,7 +544,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = org.reactjs.native.example.suite;
 				PRODUCT_NAME = SUITE;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -570,7 +570,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = org.reactjs.native.example.suite;
 				PRODUCT_NAME = SUITE;
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/SUITE/ios/SUITE/AppDelegate.mm
+++ b/SUITE/ios/SUITE/AppDelegate.mm
@@ -1,7 +1,6 @@
 #import "AppDelegate.h"
 
 #import <React/RCTBundleURLProvider.h>
-
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions

--- a/SUITE/ios/SUITE/Info.plist
+++ b/SUITE/ios/SUITE/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>LSApplicationCategoryType</key>
-	<string/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -24,46 +22,31 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>KAKAO_APP_KEY</key>
+	<string>7b0919ce4432e621c97e3df08968dd96</string>
+	<key>LSApplicationCategoryType</key>
+	<string></string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakao7b0919ce4432e621c97e3df08968dd96</string>
+		<string>kakaolink</string>
+		<string>kakaokompassauth</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-		<key>NSAppTransportSecurity</key>
+	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>카메라 사용 권한은 이미지 촬영 및 첨부를 위해 필요합니다.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string></string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>카메라 사용 권한은 이미지 촬영 및 첨부를 위해 필요합니다.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>카메라 사용 권한은 이미지 촬영 및 첨부를 위해 필요합니다.</string>
-	<!-- <key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
-	</dict> -->
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string/>
-	<key>UILaunchStoryboardName</key>
-	<string>LaunchScreen</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
-	<key>UISupportedInterfaceOrientations</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
 	<key>UIAppFonts</key>
 	<array>
 		<string>AntDesign.ttf</string>
@@ -85,5 +68,19 @@
 		<string>PretendardVariable.ttf</string>
 		<string>Oswald-Bold.ttf</string>
 	</array>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 </dict>
 </plist>

--- a/SUITE/package-lock.json
+++ b/SUITE/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@react-native-async-storage/async-storage": "^1.19.1",
         "@react-native-community/checkbox": "^0.5.16",
+        "@react-native-seoul/kakao-login": "^5.3.0",
         "@react-navigation/bottom-tabs": "^6.5.8",
         "@react-navigation/native": "^6.1.7",
         "@react-navigation/native-stack": "^6.9.13",
@@ -3361,6 +3362,18 @@
         "joi": "^17.2.1"
       }
     },
+    "node_modules/@react-native-seoul/kakao-login": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@react-native-seoul/kakao-login/-/kakao-login-5.3.0.tgz",
+      "integrity": "sha512-f0srcY39rFnPxj9+OEJirDXKl+5KPfw48o8CzVPQCJh6tcf9OgWK5yj4lJ28wmxMxDc4RSxSPvTWJ/HnTJPi5w==",
+      "dependencies": {
+        "dooboolab-welcome": "^1.3.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/@react-native/assets-registry": {
       "version": "0.72.0",
       "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.72.0.tgz",
@@ -6275,6 +6288,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dooboolab-welcome": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dooboolab-welcome/-/dooboolab-welcome-1.3.2.tgz",
+      "integrity": "sha512-2NbMaIIURElxEf/UAoVUFlXrO+7n/FRhLCiQlk4fkbGRh9cJ3/f8VEMPveR9m4Ug2l2Zey+UCXjd6EcBqHJ5bw==",
+      "hasInstallScript": true,
+      "bin": {
+        "dooboolab-welcome": "bin/hello.js"
       }
     },
     "node_modules/dot-case": {

--- a/SUITE/package.json
+++ b/SUITE/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.19.1",
     "@react-native-community/checkbox": "^0.5.16",
+    "@react-native-seoul/kakao-login": "^5.3.0",
     "@react-navigation/bottom-tabs": "^6.5.8",
     "@react-navigation/native": "^6.1.7",
     "@react-navigation/native-stack": "^6.9.13",

--- a/SUITE/src/api/Sign/externalkakaoApi.ts
+++ b/SUITE/src/api/Sign/externalkakaoApi.ts
@@ -1,0 +1,17 @@
+// import  * as KakaoLogin from '@react-native-seoul/kakao-login';
+// import { kakaoLoginApi } from './kakaoLogin';
+
+// export const externalkakaologin = () => {
+//     KakaoLogin.login().then((result) => {
+//         const data = JSON.stringify(result)
+//         const parsedData = JSON.parse(data); 
+//         const accessToken = parsedData.accessToken;
+//         kakaoLoginApi(accessToken)
+//     }).catch((error) => {
+//         if (error.code === 'E_CANCELLED_OPERATION') {
+//             console.log("Login Cancel", error.message);
+//         } else {
+//             console.log(`Login Fail(code:${error.code})`, error.message);
+//         }
+//     });
+//   };

--- a/SUITE/src/api/Sign/kakaoLogin.ts
+++ b/SUITE/src/api/Sign/kakaoLogin.ts
@@ -1,0 +1,34 @@
+import * as KakaoLogin from '@react-native-seoul/kakao-login';
+
+export const externalkakaologin = async (): Promise<any> => {
+    try {
+        const result = await KakaoLogin.login();
+        const data = JSON.stringify(result);
+        const parsedData = JSON.parse(data); 
+        const accessToken = parsedData.accessToken;
+
+        try {
+            const response = await fetch('http://semtle.catholic.ac.kr:8085/member/auth/signin', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    access_token: accessToken,
+                }),
+            });
+
+            if (response) {
+                const responseData = await response.json();
+                return responseData;
+            } else {
+                const errorData = await response.json();
+                console.log('Error occurred:', errorData);
+            }
+        } catch (error) {
+            console.log('Error occurred:', error);
+        }
+    } catch (error) {
+        console.log('Error occurred:', error);
+    }
+}

--- a/SUITE/src/api/Sign/signin.ts
+++ b/SUITE/src/api/Sign/signin.ts
@@ -10,12 +10,16 @@ export const SignInApi = async (email: string, password: string): Promise<string
           password: password,
         }),
       });
-  
-      if (response.ok) {
+      if (response) {
         const data = await response.json();
-        return data.data.accessToken;
+        if (data.statusCode == 200){
+            return data.data.accessToken
+        }
+        else if(data.statusCode == 400 || data.statusCode == 404) {
+            return data.message
+        }
       } else {
-        const data = await response.json();
+        const data = await response.json()
         throw new Error(data.data);
       }
     } catch (error) {

--- a/SUITE/src/components/presents/SignmodalPopup.tsx
+++ b/SUITE/src/components/presents/SignmodalPopup.tsx
@@ -5,9 +5,10 @@ import mainPageStyleSheet from '../../style/style';
 interface ModalPopupProps {
   visible: boolean;
   onClose: () => void;
+  text : string
 }
 
-const SignModalPopup: React.FC<ModalPopupProps> = ({ visible, onClose }) => {
+const SignModalPopup: React.FC<ModalPopupProps> = ({ visible, onClose, text }) => {
   if (!visible) {
     return null;
   }
@@ -15,7 +16,7 @@ const SignModalPopup: React.FC<ModalPopupProps> = ({ visible, onClose }) => {
   return (
     <View style={{ justifyContent: 'center', alignItems: 'center' }}>
       <Text style={mainPageStyleSheet.emailChecktext}>
-        이미 등록된 이메일이 있습니다!
+        {text}
       </Text>
       <TouchableOpacity style={mainPageStyleSheet.SignmodalButton} onPress={onClose}>
         <Text style={mainPageStyleSheet.SignmodalButtonText}>확인</Text>

--- a/SUITE/src/screens/AuthScreen/SignUp/EmailAuthentication.tsx
+++ b/SUITE/src/screens/AuthScreen/SignUp/EmailAuthentication.tsx
@@ -18,7 +18,7 @@ const EmailAuthentication = () => {
   const [email, setEmail] = useRecoilState(emailState);
   const [statusCode, setStatusCode] = useState(0)
   const [password, setpPassword] = useRecoilState(passwordState)
-  const [visible, setVisible] = React.useState(false);
+  const [visible, setVisible] = useState(false);
 
   const handlePasswordConfirmationChange = (text: string) => {
     setPasswordConfirmation(text);
@@ -114,7 +114,7 @@ const EmailAuthentication = () => {
       </View>
 
       <ModalPopup visible={visible}>  
-          <SignModalPopup visible={visible} onClose={() => setVisible(false)}/>
+          <SignModalPopup visible={visible} onClose={() => setVisible(false)} text = {'이미 등록된 이메일이 있습니다!'}/>
       </ModalPopup>
 
       <View style={mainPageStyleSheet.SignUpNextBtnContainer}> 

--- a/SUITE/yarn.lock
+++ b/SUITE/yarn.lock
@@ -1808,6 +1808,13 @@
     prompts "^2.4.0"
     semver "^6.3.0"
 
+"@react-native-seoul/kakao-login@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.npmjs.org/@react-native-seoul/kakao-login/-/kakao-login-5.3.0.tgz"
+  integrity sha512-f0srcY39rFnPxj9+OEJirDXKl+5KPfw48o8CzVPQCJh6tcf9OgWK5yj4lJ28wmxMxDc4RSxSPvTWJ/HnTJPi5w==
+  dependencies:
+    dooboolab-welcome "^1.3.2"
+
 "@react-native/assets-registry@^0.72.0":
   version "0.72.0"
   resolved "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.72.0.tgz"
@@ -3390,6 +3397,11 @@ domutils@^3.0.1:
     dom-serializer "^2.0.0"
     domelementtype "^2.3.0"
     domhandler "^5.0.3"
+
+dooboolab-welcome@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.npmjs.org/dooboolab-welcome/-/dooboolab-welcome-1.3.2.tgz"
+  integrity sha512-2NbMaIIURElxEf/UAoVUFlXrO+7n/FRhLCiQlk4fkbGRh9cJ3/f8VEMPveR9m4Ug2l2Zey+UCXjd6EcBqHJ5bw==
 
 dot-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
### 🗓️ PR 날짜 🗓️
2023-08-07 

### 🧐 구현 방법 🧐
* 로그인 시도했을 경우 아이디가 틀렸을 경우, 비밀번호가 틀렸을 경우를 API Status Code가 다르게 날아오는 걸 분기하여 각각 모달 다르게 띄울 수 있게 설정하였습니다.
* kakao 로그인을 위해 Android, ios 플랫폼 설정 때문에 설정값들이 조금 바뀌었습니다
* kakao 로그인 연동은 성공했지만, 추후 회원가입 프로세스는 논의가 조금 더 필요한 것 같습니다 (슬랙 참고)

- [x] member/signin
- [x] member/auth/signin
- [x] member/signup
- [x] member/auth/mail
- [x] member/verification/email


### 📸 UI 명세서 사진 📸

https://github.com/SWM-TheDreaming/SUITE_FRONT/assets/43203911/3c35a5af-d73d-4dfa-89c0-ace1ff2a08b0



### 실제 코드
