### PR TITLE
SUIT-21-3

### DIFF
--- a/SUITE/ios/Podfile.lock
+++ b/SUITE/ios/Podfile.lock
@@ -514,6 +514,8 @@ PODS:
   - RNCCheckbox (0.5.16):
     - BEMCheckBox (~> 1.4)
     - React-Core
+  - RNCClipboard (1.11.2):
+    - React-Core
   - RNDateTimePicker (7.4.1):
     - React-Core
   - RNGestureHandler (2.12.0):
@@ -609,6 +611,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCCheckbox (from `../node_modules/@react-native-community/checkbox`)"
+  - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
   - "RNDateTimePicker (from `../node_modules/@react-native-community/datetimepicker`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNImageCropPicker (from `../node_modules/react-native-image-crop-picker`)
@@ -730,6 +733,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-async-storage/async-storage"
   RNCCheckbox:
     :path: "../node_modules/@react-native-community/checkbox"
+  RNCClipboard:
+    :path: "../node_modules/@react-native-clipboard/clipboard"
   RNDateTimePicker:
     :path: "../node_modules/@react-native-community/datetimepicker"
   RNGestureHandler:
@@ -807,6 +812,7 @@ SPEC CHECKSUMS:
   ReactCommon: 3ccb8fb14e6b3277e38c73b0ff5e4a1b8db017a9
   RNCAsyncStorage: f47fe18526970a69c34b548883e1aeceb115e3e1
   RNCCheckbox: 75255b03e604bbcc26411eb31c4cbe3e3865f538
+  RNCClipboard: 3f0451a8100393908bea5c5c5b16f96d45f30bfc
   RNDateTimePicker: 9b4091348e53f540180abdc54984d839a556f593
   RNGestureHandler: dec4645026e7401a0899f2846d864403478ff6a5
   RNImageCropPicker: 486e2f7e2b0461ce24321f751410dce1b3b49e6d

--- a/SUITE/package-lock.json
+++ b/SUITE/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^1.19.1",
+        "@react-native-clipboard/clipboard": "^1.11.2",
         "@react-native-community/checkbox": "^0.5.16",
         "@react-native-community/datetimepicker": "^7.4.1",
         "@react-native-seoul/kakao-login": "^5.3.0",
@@ -3041,6 +3042,15 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || 0.60 - 0.72 || 1000.0.0"
+      }
+    },
+    "node_modules/@react-native-clipboard/clipboard": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@react-native-clipboard/clipboard/-/clipboard-1.11.2.tgz",
+      "integrity": "sha512-bHyZVW62TuleiZsXNHS1Pv16fWc0fh8O9WvBzl4h2fykqZRW9a+Pv/RGTH56E3X2PqzHP38K5go8zmCZUoIsoQ==",
+      "peerDependencies": {
+        "react": ">=16.0",
+        "react-native": ">=0.57.0"
       }
     },
     "node_modules/@react-native-community/checkbox": {

--- a/SUITE/package.json
+++ b/SUITE/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.19.1",
+    "@react-native-clipboard/clipboard": "^1.11.2",
     "@react-native-community/checkbox": "^0.5.16",
     "@react-native-community/datetimepicker": "^7.4.1",
     "@react-native-seoul/kakao-login": "^5.3.0",

--- a/SUITE/recoil/atoms.ts
+++ b/SUITE/recoil/atoms.ts
@@ -84,3 +84,7 @@ export const channelLinkState = atom({
   key: 'channelLinkState',
   default: '',
 });
+export const payNameState = atom({
+  key: 'payNameState',
+  default: '',
+});

--- a/SUITE/src/hook/header.tsx
+++ b/SUITE/src/hook/header.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 import mainPageStyleSheet from '../style/style';
 import Icon from 'react-native-vector-icons/Ionicons';
 import { useNavigation } from '@react-navigation/core';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { RootStackParamList } from '../types';
-
 export type RootStackNavigationProp = StackNavigationProp<RootStackParamList>;
 
 interface HeaderProps {
@@ -15,8 +14,10 @@ interface HeaderProps {
 
 export const Header: React.FC<HeaderProps> = ({ title, backScreen }) => {
   const navigation = useNavigation<RootStackNavigationProp>();
+  const [visible, setVisible] = useState(false);
 
   const handleBackPress = () => {
+    // setVisible(true)
     if (backScreen) {
       navigation.navigate(backScreen);
     } else {

--- a/SUITE/src/navigation/appStack.tsx
+++ b/SUITE/src/navigation/appStack.tsx
@@ -10,6 +10,7 @@ import SuiteRoomInfo from '../screens/SutieRoomCreate/SuiteRoomInfo';
 import SuiteRoompay from '../screens/SutieRoomCreate/SuiteRoompay';
 import SuiteRoomurl from '../screens/SutieRoomCreate/SuiteRoomurl';
 import SuiteRoomRule from '../screens/SutieRoomCreate/SuiteRoomRule';
+import SuiteRoompayCheck from '../screens/SutieRoomCreate/SuiteRoompayCheck';
 const App = createStackNavigator<RootStackParamList>();
 
 export function AppStack() {
@@ -57,6 +58,14 @@ export function AppStack() {
       <App.Screen
         name="SuiteRoomRule"
         component={SuiteRoomRule}
+        options={{
+          headerShown: false,
+          ...TransitionPresets.RevealFromBottomAndroid,
+        }}
+      />
+       <App.Screen
+        name="SuiteRoompayCheck"
+        component={SuiteRoompayCheck}
         options={{
           headerShown: false,
           ...TransitionPresets.RevealFromBottomAndroid,

--- a/SUITE/src/screens/SutieRoomCreate/SuiteRoomInfo.tsx
+++ b/SUITE/src/screens/SutieRoomCreate/SuiteRoomInfo.tsx
@@ -7,7 +7,7 @@ import { RootStackParamList } from '../../types';
 import suiteRoomForm from '../../hook/suiteRoomForm';
 import InputField from '../../components/presents/InputField';
 import * as Progress from 'react-native-progress';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { Dimensions } from 'react-native';
 import { SelectList } from 'react-native-dropdown-select-list';
 import { Category } from '../../data/Categoty';
@@ -31,11 +31,11 @@ const SuiteRoomInfo = () => {
   const [studyDeadLine, setstudyDeadLine] = useState(new Date());
   const [participantCount, setParticipantCount] = useState(1);
   const navigation = useNavigation<RootStackNavigationProp>();
-  const setSuiteRoomState = useSetRecoilState(suiteRoomState);
-  const setSubjectState = useSetRecoilState(subjectState);
-  const setRecruitmentDeadLineState = useSetRecoilState(recruitmentDeadLineState);
-  const setStudyDeadLineState = useSetRecoilState(studyDeadLineState);
-  const setRecruitmentLimitState = useSetRecoilState(recruitmentLimitState);
+  const [recoilSuiteRoomTitle, setSuiteRoomState] = useRecoilState(suiteRoomState);
+  const [recoilSubject, setSubjectState] = useRecoilState(subjectState);
+  const [recoilRecruitmentDeadLine, setRecruitmentDeadLineState] = useRecoilState(recruitmentDeadLineState);
+  const [recoilStudyDeadLine, setStudyDeadLineState] = useRecoilState(studyDeadLineState);
+  const [recoilRecruitmentLimit, setRecruitmentLimitState] = useRecoilState(recruitmentLimitState);
 
   const handleButtonPress = () => {
     setSuiteRoomState(suiteRoomInfo.getTextInputProps('title').value);
@@ -82,7 +82,7 @@ const SuiteRoomInfo = () => {
         <InputField
           style={mainPageStyleSheet.idpwInputBox}
           autoFocus
-          placeholder=" 제목을 입력해주세요"
+          placeholder= " 제목을 입력해주세요"
           maxLength={50}
           {...suiteRoomInfo.getTextInputProps('title')}
           touched={suiteRoomInfo.touched.title}

--- a/SUITE/src/screens/SutieRoomCreate/SuiteRoomRule.tsx
+++ b/SUITE/src/screens/SutieRoomCreate/SuiteRoomRule.tsx
@@ -86,7 +86,7 @@ const SuiteRoomRule = () => {
   ]);
   return (
     <View style={mainPageStyleSheet.categoryPageContainer}>
-      <Header title="Suite Room 개설" backScreen="Studylist" />
+      <Header title="Suite Room 개설" backScreen="SuiteRoomInfo" />
       <Progress.Bar
         progress={0.6}
         height={2}

--- a/SUITE/src/screens/SutieRoomCreate/SuiteRoompay.tsx
+++ b/SUITE/src/screens/SutieRoomCreate/SuiteRoompay.tsx
@@ -9,16 +9,20 @@ import { Header } from '../../hook/header';
 import InputField from '../../components/presents/InputField';
 import suiteRoomForm from '../../hook/suiteRoomForm';
 import { useRecoilValue } from 'recoil';
-import { depositAmountState } from '../../../recoil/atoms';
+import { useSetRecoilState } from 'recoil';
+import { depositAmountState, payNameState } from '../../../recoil/atoms';
 export type RootStackNavigationProp = StackNavigationProp<RootStackParamList>;
 
 const SuiteRoompay = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
   const suiteRoomPay = suiteRoomForm();
   const depositAmount = useRecoilValue(depositAmountState)
+  const setPayNameState = useSetRecoilState(payNameState)
   const [isButtonDisabled, setIsButtonDisabled] = useState(true);
   const handleButtonPress = () => {
-  
+    setPayNameState(suiteRoomPay.getTextInputProps('name').value)
+    //스터디룸 생성 API 코드 연동 예정
+    navigation.navigate('SuiteRoompayCheck')
   };
   useEffect(() => {
     if (suiteRoomPay.getTextInputProps('name').value != ''){
@@ -29,7 +33,7 @@ const SuiteRoompay = () => {
   }, [suiteRoomPay.getTextInputProps('name').value]);
   return (
     <View style={mainPageStyleSheet.categoryPageContainer}>
-      <Header title="Suite Room 체크인" backScreen="Studylist" />
+      <Header title="Suite Room 체크인" backScreen="SuiteRoomurl" />
       <View style={mainPageStyleSheet.emailAuthenticationContainer}>
         <Text style={mainPageStyleSheet.idpwtext}>보증 금액</Text>
         <View style = {mainPageStyleSheet.depositCheckBox}>

--- a/SUITE/src/screens/SutieRoomCreate/SuiteRoompayCheck.tsx
+++ b/SUITE/src/screens/SutieRoomCreate/SuiteRoompayCheck.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TouchableOpacity, Button } from 'react-native';
+import mainPageStyleSheet from '../../style/style';
+import { useNavigation } from '@react-navigation/core';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RootStackParamList } from '../../types';
+import suiteRoomForm from '../../hook/suiteRoomForm';
+import { useRecoilValue } from 'recoil';
+import { depositAmountState, payNameState } from '../../../recoil/atoms';
+import Clipboard from '@react-native-clipboard/clipboard';
+import Icon from 'react-native-vector-icons/FontAwesome';
+
+export type RootStackNavigationProp = StackNavigationProp<RootStackParamList>;
+
+const SuiteRoompayCheck = () => {
+  const navigation = useNavigation<RootStackNavigationProp>();
+  const suiteRoomPay = suiteRoomForm();
+  const depositAmount = useRecoilValue(depositAmountState)
+  const payName = useRecoilValue(payNameState)
+
+  const handleCopyToClipboard = () => {
+    Clipboard.setString('농협 352-0514-9812-13');
+  };
+
+  const handleButtonPress = () => {
+    navigation.navigate('Studylist')
+  };
+  return (
+    <View style={mainPageStyleSheet.categoryPageContainer}>
+      <View style={mainPageStyleSheet.emailAuthenticationContainer}>
+          <Text style={mainPageStyleSheet.payInfoText}>아래내역으로 입금해주세요</Text>
+          <Text style={mainPageStyleSheet.payInfosubText}>입금이 확인되면 카카오톡 채널로 알려드려요!</Text>
+        <View style={mainPageStyleSheet.payCheckBox}>
+            <Text style={mainPageStyleSheet.payCheckText}>입금자명 : {payName}</Text>
+            <Text style={mainPageStyleSheet.payCheckText}>입금금액 : {depositAmount}원</Text>
+            <View style= {{flexDirection : 'row'}}>
+                <Text style={mainPageStyleSheet.payCheckText}>계좌 정보 : 농협 352-0514-9812-13</Text>
+                <View style={mainPageStyleSheet.accountNumberCopyBox}>
+                <TouchableOpacity onPress={handleCopyToClipboard} style={mainPageStyleSheet.accountNumberCopyContainer}>
+                    <Text style={mainPageStyleSheet.accountNumberCopyText}>복사</Text>
+                </TouchableOpacity>
+                </View>
+            </View>
+            <Text style={mainPageStyleSheet.payCheckText}>예금주 : 유정협</Text>
+        </View>
+        <View style={mainPageStyleSheet.depositInformationContainer}>
+          <View style={mainPageStyleSheet.depositInformationTextContainer}>
+             <Icon name="exclamation-circle" size={15} color={'#F14A4A'} style={mainPageStyleSheet.depositInformationIcon}/>
+            <Text style={mainPageStyleSheet.depositInformationText}>주의사항</Text>
+          </View>
+          <Text style={mainPageStyleSheet.depositDetailInformationText}>• 3일 안에 입금하지 않으시면 자동 취소 됩니다</Text>
+          <Text style={mainPageStyleSheet.depositDetailInformationText}>• 입금 완료 후 스터디 모집이 가능합니다</Text>
+        </View>
+        </View>
+        <View style={mainPageStyleSheet.SignUpNextBtnContainer}>
+        <TouchableOpacity
+          style={mainPageStyleSheet.SignUpNextBtnBtn}
+          onPress={() => {
+            handleButtonPress();
+          }}
+        >
+          <Text style={mainPageStyleSheet.SignUpNextBtnText}>스터디 생성 완료</Text>
+        </TouchableOpacity>
+      </View> 
+    </View>
+  );
+};
+
+export default SuiteRoompayCheck;

--- a/SUITE/src/screens/SutieRoomCreate/SuiteRoomurl.tsx
+++ b/SUITE/src/screens/SutieRoomCreate/SuiteRoomurl.tsx
@@ -39,7 +39,7 @@ const SuiteRoomurl = () => {
   }, [suiteRoomUrl.getTextInputProps('content').value, suiteRoomUrl.getTextInputProps('channelLink').value]);
   return (
     <View style={mainPageStyleSheet.categoryPageContainer}>
-      <Header title="Suite Room 개설" backScreen="Studylist" />
+      <Header title="Suite Room 개설" backScreen="SuiteRoomRule" />
       <Progress.Bar
         progress={1.0}
         height={2}

--- a/SUITE/src/style/style.js
+++ b/SUITE/src/style/style.js
@@ -756,6 +756,56 @@ const mainPageStyleSheet = StyleSheet.create({
     fontFamily: 'PretendardVariable',
     fontSize : 13,
     color : '#484848'
+  },
+  payCheckBox: {
+    backgroundColor: '#050953',
+    width: widthPercentage(312),
+    height: heightPercentage(266),
+    marginTop : heightPercentage(30),
+    borderRadius: 10,
+    paddingLeft: 15,
+    paddingTop: 12,
+  },
+  payInfoText :{
+    color : 'black',
+    fontSize : 20,
+    fontWeight:'bold',
+    fontFamily: 'PretendardVariable',
+    paddingLeft: 5
+  },
+  payInfosubText :{
+    color : '#888888',
+    fontSize : 13,
+    fontFamily: 'PretendardVariable',
+    paddingLeft: 5,
+    paddingTop : 5
+  },
+  payCheckText : {
+    paddingLeft : 20,
+    paddingTop : 25,
+    color : 'white',
+    fontSize: 13,
+    fontWeight : 'bold',
+    fontFamily: 'PretendardVariable',
+  },
+  accountNumberCopyBox:{
+    justifyContent : 'flex-end',
+    marginLeft : 7
+  },
+  accountNumberCopyContainer:{
+    backgroundColor : '#FFC763',
+    borderRadius : 7,
+    height : 15,
+    width: 20,
+    justifyContent : 'center',
+    alignItems : 'center'
+  },
+  accountNumberCopyText :{
+    color : '#050953',
+    fontSize : 9,
+    fontFamily: 'PretendardVariable',
+    textAlign : 'center',
+    fontWeight : 'bold'
   }
 });
 

--- a/SUITE/src/types.ts
+++ b/SUITE/src/types.ts
@@ -15,6 +15,7 @@ export type RootStackParamList = {
   SuiteRoomInfo: undefined;
   SuiteRoompay: undefined;
   SuiteRoomRule: undefined;
+  SuiteRoompayCheck: undefined
 };
 
 export interface Category {

--- a/SUITE/yarn.lock
+++ b/SUITE/yarn.lock
@@ -1639,6 +1639,11 @@
   dependencies:
     merge-options "^3.0.4"
 
+"@react-native-clipboard/clipboard@^1.11.2":
+  version "1.11.2"
+  resolved "https://registry.npmjs.org/@react-native-clipboard/clipboard/-/clipboard-1.11.2.tgz"
+  integrity sha512-bHyZVW62TuleiZsXNHS1Pv16fWc0fh8O9WvBzl4h2fykqZRW9a+Pv/RGTH56E3X2PqzHP38K5go8zmCZUoIsoQ==
+
 "@react-native-community/checkbox@^0.5.16":
   version "0.5.16"
   resolved "https://registry.npmjs.org/@react-native-community/checkbox/-/checkbox-0.5.16.tgz"
@@ -6389,7 +6394,7 @@ react-native-vector-icons@^10.0.0, react-native-vector-icons@>7.0.0:
     prop-types "^15.7.2"
     yargs "^16.1.1"
 
-react-native@*, "react-native@^0.0.0-0 || 0.60 - 0.72 || 1000.0.0", "react-native@>= 0.62", "react-native@>= 0.64.3", react-native@>=0.40.0, react-native@>=0.42.0, react-native@>=0.44.1, react-native@>=0.48.0, react-native@>=0.59.0, react-native@0.72.3:
+react-native@*, "react-native@^0.0.0-0 || 0.60 - 0.72 || 1000.0.0", "react-native@>= 0.62", "react-native@>= 0.64.3", react-native@>=0.40.0, react-native@>=0.42.0, react-native@>=0.44.1, react-native@>=0.48.0, react-native@>=0.57.0, react-native@>=0.59.0, react-native@0.72.3:
   version "0.72.3"
   resolved "https://registry.npmjs.org/react-native/-/react-native-0.72.3.tgz"
   integrity sha512-QqISi+JVmCssNP2FlQ4MWhlc4O/I00MRE1/GClvyZ8h/6kdsyk/sOirkYdZqX3+DrJfI3q+OnyMnsyaXIQ/5tQ==
@@ -6453,7 +6458,7 @@ react-test-renderer@18.2.0:
     react-shallow-renderer "^16.15.0"
     scheduler "^0.23.0"
 
-react@*, "react@^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", react@^18.2.0, "react@>= 16.8.0", "react@>= 17.0.1", react@>=16.13.1, react@>=16.8, react@>=17.0.0, react@18.2.0:
+react@*, "react@^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", react@^18.2.0, "react@>= 16.8.0", "react@>= 17.0.1", react@>=16.0, react@>=16.13.1, react@>=16.8, react@>=17.0.0, react@18.2.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==


### PR DESCRIPTION
### 🗓️ PR 날짜 🗓️
2023/08/11 

### 🧐 구현 방법 🧐
* 스터디 개설 프로세스 마지막에, 보증금과 입금자명을 확인하고 해당 계좌로 송금할 수 있게 보여주는 UI 세팅해주었습니다.
* 추가로 스터디 개설 프로세스는 회원가입과 다르게 뒤로가더라도 메인 페이지로 가지 않고, 바로 뒤 프로세스로 갈 수 있게 해주었습니다.
* API 는 서버에 올라가는데로 연동할 예정이고, 이제 스터디 상세 페이지 제작할 예정입니다.

### 📸 UI 명세서 사진 📸

https://github.com/SWM-TheDreaming/SUITE_FRONT/assets/43203911/36494c8f-88b5-441f-92e4-cf2bca79d7a2


### 실제 코드
