### PR TITLE
SUIT-25-1

### DIFF
--- a/SUITE/src/components/containers/studyInfoCard.container.tsx
+++ b/SUITE/src/components/containers/studyInfoCard.container.tsx
@@ -6,14 +6,14 @@ import { TextInput } from 'react-native-gesture-handler';
 import Icon from 'react-native-vector-icons/Entypo';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { RootStackParamList } from '../../types';
-import { useNavigation, useRoute } from '@react-navigation/native';
-import { RouteProp, useFocusEffect } from '@react-navigation/core';
+import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect } from '@react-navigation/core';
 import { Category } from '../../types';
 export type RootStackNavigationProp = StackNavigationProp<RootStackParamList>;
 
 const mockdata = [
   {
-    id: 1,
+    id: '123',
     title: '임용 시험 합격 준비반 스터디 모집',
     studyDeadLine: new Date('2023-06-13'),
     recruitmentDeadLine: new Date('2023-06-13'),
@@ -25,7 +25,7 @@ const mockdata = [
     scrab: 5,
   },
   {
-    id: 2,
+    id: '234',
     title: 'TOEIC 스터디 모집',
     studyDeadLine: new Date('2023-07-13'),
     recruitmentDeadLine: new Date('2023-07-13'),
@@ -37,7 +37,7 @@ const mockdata = [
     scrab: 2,
   },
   {
-    id: 3,
+    id: '345',
     title: '코테 스터디 모집',
     studyDeadLine: new Date('2023-08-13'),
     recruitmentDeadLine: new Date('2023-08-13'),
@@ -100,6 +100,7 @@ const StudyInfoCard: React.FunctionComponent<Category> = ({ filterCategory }) =>
       {mockdata.map((item) => (
         <StudyInfoCardUI
           key={item.id}
+          id={item.id}
           title={item.title}
           studyDeadLine={item.studyDeadLine}
           recruitmentDeadLine={item.recruitmentDeadLine}

--- a/SUITE/src/components/presents/TagComponent.tsx
+++ b/SUITE/src/components/presents/TagComponent.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import mainPageStyleSheet from '../../style/style';
+
+interface TagComponentProps {
+  dDay: string;
+  category: string;
+  depositAmount: string;
+}
+
+const TagComponent: React.FC<TagComponentProps> = ({ dDay, category, depositAmount }) => {
+  return (
+    <View style={mainPageStyleSheet.tag}>
+      <View style={mainPageStyleSheet.ddaybox}>
+        <Text style={mainPageStyleSheet.mainPageSmallBoxtext}>{dDay}</Text>
+      </View>
+      <View style={mainPageStyleSheet.categorybox}>
+        <Text style={mainPageStyleSheet.mainPageSmallBoxtext}>{category}</Text>
+      </View>
+      <View style={mainPageStyleSheet.depositamountbox}>
+        <Text style={mainPageStyleSheet.depositamounttext}>{depositAmount}</Text>
+      </View>
+    </View>
+  );
+};
+
+export default TagComponent;

--- a/SUITE/src/components/presents/studyInfoCard.present.tsx
+++ b/SUITE/src/components/presents/studyInfoCard.present.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { Text, View, TouchableOpacity } from 'react-native';
 import mainPageStyleSheet from '../../style/style';
+import { RootStackParamList } from '../../types';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { useNavigation } from '@react-navigation/native';
+export type RootStackNavigationProp = StackNavigationProp<RootStackParamList>;
+
 export interface StudyInfoCardProps {
+  id : string;
   title: string; //스터디 이름
   studyDeadLine: Date; //스터디 종료날짜
   recruitmentDeadLine: Date; //스터디 신청 마감 기한
@@ -13,8 +19,13 @@ export interface StudyInfoCardProps {
   scrab: number;
 }
 const StudyInfoCardUI = (props: StudyInfoCardProps) => {
+  const navigation = useNavigation<RootStackNavigationProp>();
   return (
-    <TouchableOpacity style={mainPageStyleSheet.box}>
+    <TouchableOpacity style={mainPageStyleSheet.box}
+    onPress={() => {
+      console.log(props.id)
+      navigation.navigate('SuiteRoomDetail',{SuiteRoomid : props.id});
+    }}>
       <View style={mainPageStyleSheet.innerbox}>
         <View style={mainPageStyleSheet.tag}>
           <View style={mainPageStyleSheet.ddaybox}>

--- a/SUITE/src/components/presents/studyInfoCard.present.tsx
+++ b/SUITE/src/components/presents/studyInfoCard.present.tsx
@@ -4,6 +4,7 @@ import mainPageStyleSheet from '../../style/style';
 import { RootStackParamList } from '../../types';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { useNavigation } from '@react-navigation/native';
+import TagComponent from './TagComponent';
 export type RootStackNavigationProp = StackNavigationProp<RootStackParamList>;
 
 export interface StudyInfoCardProps {
@@ -27,17 +28,11 @@ const StudyInfoCardUI = (props: StudyInfoCardProps) => {
       navigation.navigate('SuiteRoomDetail',{SuiteRoomid : props.id});
     }}>
       <View style={mainPageStyleSheet.innerbox}>
-        <View style={mainPageStyleSheet.tag}>
-          <View style={mainPageStyleSheet.ddaybox}>
-            <Text style={mainPageStyleSheet.mainPageSmallBoxtext}>D-12</Text>
-          </View>
-          <View style={mainPageStyleSheet.categorybox}>
-            <Text style={mainPageStyleSheet.mainPageSmallBoxtext}>{props.category}</Text>
-          </View>
-          <View style={mainPageStyleSheet.depositamountbox}>
-            <Text style={mainPageStyleSheet.depositamounttext}>{props.depositAmount.toString().slice(0, 2)}K</Text>
-          </View>
-        </View>
+        <TagComponent
+          dDay="D-12"
+          category={props.category}
+          depositAmount={`${props.depositAmount.toString().slice(0, 2)}K`}
+        />
         <Text style={mainPageStyleSheet.titletext}>{props.title}</Text>
         <Text style={mainPageStyleSheet.detailtext}>
           방장: mimo | 참여인원:{props.presentRecruitment}/{props.recruitmentLimit}

--- a/SUITE/src/navigation/appStack.tsx
+++ b/SUITE/src/navigation/appStack.tsx
@@ -11,6 +11,7 @@ import SuiteRoompay from '../screens/SutieRoomCreate/SuiteRoompay';
 import SuiteRoomurl from '../screens/SutieRoomCreate/SuiteRoomurl';
 import SuiteRoomRule from '../screens/SutieRoomCreate/SuiteRoomRule';
 import SuiteRoompayCheck from '../screens/SutieRoomCreate/SuiteRoompayCheck';
+import SuiteRoomDetail from '../screens/SuiteRoom/SuiteRoomDetail';
 const App = createStackNavigator<RootStackParamList>();
 
 export function AppStack() {
@@ -66,6 +67,14 @@ export function AppStack() {
        <App.Screen
         name="SuiteRoompayCheck"
         component={SuiteRoompayCheck}
+        options={{
+          headerShown: false,
+          ...TransitionPresets.RevealFromBottomAndroid,
+        }}
+      />
+      <App.Screen
+        name="SuiteRoomDetail"
+        component={SuiteRoomDetail}
         options={{
           headerShown: false,
           ...TransitionPresets.RevealFromBottomAndroid,

--- a/SUITE/src/screens/SuiteRoom/SuiteRoomDetail.tsx
+++ b/SUITE/src/screens/SuiteRoom/SuiteRoomDetail.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { RouteProp } from '@react-navigation/native';
+import { RootStackParamList } from '../../types';
+
+type SuiteRoomDetailRouteProp = RouteProp<RootStackParamList, 'SuiteRoomDetail'>;
+
+interface SuiteRoomDetailProps {
+  route: SuiteRoomDetailRouteProp;
+}
+
+const SuiteRoomDetail: React.FunctionComponent<SuiteRoomDetailProps> = ({ route }) => {
+  const { SuiteRoomid } = route.params;
+  console.log(SuiteRoomid)
+  return (
+    <View>
+      <Text>SuiteRoomDetail page - SuiteRoomId: {SuiteRoomid}</Text>
+    </View>
+  );
+};
+
+export default SuiteRoomDetail;

--- a/SUITE/src/screens/SuiteRoom/SuiteRoomDetail.tsx
+++ b/SUITE/src/screens/SuiteRoom/SuiteRoomDetail.tsx
@@ -1,21 +1,72 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, ScrollView, Image } from 'react-native';
 import { RouteProp } from '@react-navigation/native';
 import { RootStackParamList } from '../../types';
+import {Header} from "../../hook/header"
+import SuiteRoomStyleSheet from "../../style/SuiteRoom"
+import TagComponent from "../../components/presents/TagComponent"
+import Feather from 'react-native-vector-icons/Feather';
+import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
+import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
+
 
 type SuiteRoomDetailRouteProp = RouteProp<RootStackParamList, 'SuiteRoomDetail'>;
 
 interface SuiteRoomDetailProps {
   route: SuiteRoomDetailRouteProp;
 }
-
+const mockdata = 
+    {
+      id: '123',
+      title: '임용 시험 합격 준비반 스터디 모집',
+      studyDeadLine: '2023-06-13',
+      recruitmentDeadLine: '2023-06-13',
+      category: '공무원',
+      depositAmount: 10000,
+      recruitmentLimit: 5,
+      presentRecruitment: 2,
+      writeDate: new Date('2023-06-13'),
+      scrab: 5,
+    }
+  ;
 const SuiteRoomDetail: React.FunctionComponent<SuiteRoomDetailProps> = ({ route }) => {
   const { SuiteRoomid } = route.params;
-  console.log(SuiteRoomid)
   return (
-    <View>
-      <Text>SuiteRoomDetail page - SuiteRoomId: {SuiteRoomid}</Text>
+    <ScrollView>
+    <View style={SuiteRoomStyleSheet.SuiteRoomDetailContainer}>
+        <Header title={''} backScreen= 'Studylist'/>
+        <View style={SuiteRoomStyleSheet.SuiteRoomDetailupperBox}>
+        <TagComponent
+             dDay="D-12"
+             category={mockdata.category}
+             depositAmount={`${mockdata.depositAmount.toString().slice(0, 2)}K`}
+        />
+        <Text style={SuiteRoomStyleSheet.SuiteRoomDetailTitle}>{mockdata.title}</Text>
+        <View style={SuiteRoomStyleSheet.SuiteRoomDetailUpperBox}>
+            <View style={SuiteRoomStyleSheet.SuiteRoomBoxIconContainer}>
+                <Feather name="users" size={20} color={'#686868'}/>
+                <Text style = {SuiteRoomStyleSheet.SuiteRoomBoxText}>참여인원</Text>
+                <Text style = {SuiteRoomStyleSheet.SuiteRoomBoxData}>{mockdata.presentRecruitment}/{mockdata.recruitmentLimit}</Text>
+            </View>
+            <View style={SuiteRoomStyleSheet.SuiteRoomBoxIconContainer}>
+                <MaterialCommunityIcons name="timer-outline" size={20} color={'#686868'}/>
+                <Text style = {SuiteRoomStyleSheet.SuiteRoomBoxText}>모집기간</Text>
+                <Text style = {SuiteRoomStyleSheet.SuiteRoomBoxData}>{mockdata.recruitmentDeadLine}</Text>
+            </View>
+            <View style={SuiteRoomStyleSheet.SuiteRoomBoxIconContainer}>
+                <MaterialCommunityIcons name="calendar-clock-outline" size={20} color={'#686868'}/>
+                <Text style = {SuiteRoomStyleSheet.SuiteRoomBoxText}>스터디기간</Text>
+                <Text style = {SuiteRoomStyleSheet.SuiteRoomBoxData}>{mockdata.studyDeadLine}</Text>
+            </View>
+            <View style={SuiteRoomStyleSheet.SuiteRoomBoxIconContainer}>
+                <MaterialIcons name="payment" size={20} color={'#686868'}/>
+                <Text style = {SuiteRoomStyleSheet.SuiteRoomBoxText}>보증금</Text>
+                <Text style = {SuiteRoomStyleSheet.SuiteRoomBoxData}>{mockdata.depositAmount}원</Text>
+            </View>
+        </View>
+        </View>
     </View>
+    </ScrollView>
   );
 };
 

--- a/SUITE/src/style/SuiteRoom.js
+++ b/SUITE/src/style/SuiteRoom.js
@@ -1,0 +1,52 @@
+import { StyleSheet, Platform } from 'react-native';
+import { heightPercentage, widthPercentage } from '../responsive/ResponsiveSize';
+import { Dimensions } from 'react-native';
+const Width = Dimensions.get('window').width; //스크린 너비 초기화
+const Height = Dimensions.get('window').height; //스크린 높이 초기화
+const SuiteRoomStyleSheet = StyleSheet.create({
+    SuiteRoomDetailContainer:{
+        backgroundColor:'white',
+        height : Height
+    },
+    SuiteRoomDetailupperBox:{
+        marginLeft : widthPercentage(20),
+        marginRight : widthPercentage(20),
+        marginTop : heightPercentage(40)
+    },
+    SuiteRoomDetailTitle:{
+        fontSize : 18,
+        color : 'black',
+        fontWeight : 'bold',
+        marginTop : heightPercentage(14)
+    },
+    SuiteRoomDetailUpperBox :{
+        height: heightPercentage(100),
+        width: widthPercentage(320),
+        marginTop : heightPercentage(16),
+        backgroundColor : "#F8F8F8",
+        borderRadius : 4,
+        flexDirection : 'row',
+        justifyContent : 'center',
+    },
+    SuiteRoomBoxIconContainer : {
+        marginLeft : widthPercentage(15),
+        marginRight : widthPercentage(15),
+        marginTop : heightPercentage(20),
+        flexDirection : 'column',
+        alignItems : 'center'
+    },
+    SuiteRoomBoxText : {
+        fontSize : 10,
+        fontFamily: 'PretendardVariable',
+        color : '#686868',
+        marginTop : 2,
+    },
+    SuiteRoomBoxData:{
+        fontSize : 10,
+        fontFamily: 'PretendardVariable',
+        color : 'black',
+        marginTop : 2,
+    }
+});
+
+export default SuiteRoomStyleSheet;

--- a/SUITE/src/types.ts
+++ b/SUITE/src/types.ts
@@ -15,7 +15,8 @@ export type RootStackParamList = {
   SuiteRoomInfo: undefined;
   SuiteRoompay: undefined;
   SuiteRoomRule: undefined;
-  SuiteRoompayCheck: undefined
+  SuiteRoompayCheck: undefined;
+  SuiteRoomDetail : {SuiteRoomid : string};
 };
 
 export interface Category {
@@ -24,4 +25,7 @@ export interface Category {
         selectedCategories: string[] | undefined;
       }
     | undefined;
+}
+export interface SuiteRoomId {
+      SuiteRoomid: string;
 }


### PR DESCRIPTION
### 🗓️ PR 날짜 🗓️
2023/08/11 


### 🧐 구현 방법 🧐
* 스터디 목록 페이지에서 상세 페이지로 이동하기 위해 라우팅 설정해주고, 해당 페이지로 데이터 넘겨주었습니다.
* 전체 페이지 UI잡고, 우선은 디자인에 잇는 윗부분만 완성해주었습니다.
* 다음 작업은 아래 부분 UI 진행할 것 같습니다.

### 📸 UI 명세서 사진 📸

https://github.com/SWM-TheDreaming/SUITE_FRONT/assets/43203911/97de21c2-b1b8-429b-bfbd-b93af1c5dd0a


### 실제 코드
