### PR TITLE
SUIT-68-2

### DIFF
--- a/SUITE/src/hook/myAttendanceTable.tsx
+++ b/SUITE/src/hook/myAttendanceTable.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+type DataRow = {
+  nickname: string;
+  attendance: string;
+  missionCompletion: string;
+};
+
+const data: DataRow[] = [
+  { nickname: '', attendance: '', missionCompletion: '' },
+  { nickname: '1', attendance: '2023-07-15', missionCompletion: 'O' },
+  { nickname: '2', attendance: '2023-07-16', missionCompletion: 'X' },
+  { nickname: '3', attendance: '2023-07-17', missionCompletion: 'O' },
+  { nickname: '4', attendance: '2023-07-18', missionCompletion: 'O' },
+  { nickname: '5', attendance: '2023-07-19', missionCompletion: 'O' },
+];
+
+const MyAttendanceTable: React.FC = () => {
+  return (
+    <View style={styles.container}>
+      {data.map((item, index) => (
+        <View
+          key={index}
+          style={[styles.row, index % 2 === 0 ? styles.evenRow : styles.oddRow, index === 0 ? styles.headerRow : null]}
+        >
+          <Text style={styles.firstColumn}>{index === 0 ? '회차' : item.nickname}</Text>
+          <Text style={styles.secondColumn}>{index === 0 ? '출석일자' : item.attendance}</Text>
+          <Text style={styles.thirdColumn}>{index === 0 ? '출석여부' : item.missionCompletion}</Text>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: 10,
+    paddingTop: 20,
+  },
+  headerRow: {
+    backgroundColor: '#E5F5FF',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+  },
+  oddRow: {
+    backgroundColor: 'white',
+  },
+  evenRow: {
+    backgroundColor: '#F8F8F8',
+  },
+  cell: {
+    textAlign: 'center',
+    flex: 1,
+  },
+  firstColumn: {
+    width: 60,
+    textAlign: 'center',
+    color: 'black',
+    fontWeight: 'bold',
+    fontSize: 14,
+    fontFamily: 'PretendardVariable',
+  },
+  secondColumn: {
+    width: 180,
+    textAlign: 'center',
+    color: 'black',
+    fontWeight: 'bold',
+    fontSize: 14,
+    fontFamily: 'PretendardVariable',
+  },
+  thirdColumn: {
+    width: 80,
+    textAlign: 'center',
+    color: 'black',
+    fontWeight: 'bold',
+    fontSize: 14,
+    fontFamily: 'PretendardVariable',
+  },
+});
+
+export default MyAttendanceTable;

--- a/SUITE/src/hook/studyStatusTable.tsx
+++ b/SUITE/src/hook/studyStatusTable.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+type DataRow = {
+  nickname: string;
+  attendance: string;
+  missionCompletion: string;
+};
+
+const data: DataRow[] = [
+  { nickname: '', attendance: '', missionCompletion: '' },
+  { nickname: 'one8775', attendance: '85%', missionCompletion: '70%' },
+  { nickname: 'dareren', attendance: '90%', missionCompletion: '80%' },
+  { nickname: 'Songpe', attendance: '85%', missionCompletion: '70%' },
+  { nickname: 'Son', attendance: '90%', missionCompletion: '80%' },
+  { nickname: 'KangInLee', attendance: '85%', missionCompletion: '70%' },
+];
+
+const StudyStatusTable: React.FC = () => {
+  return (
+    <View style={styles.container}>
+      {data.map((item, index) => (
+        <View
+          key={index}
+          style={[styles.row, index % 2 === 0 ? styles.evenRow : styles.oddRow, index === 0 ? styles.headerRow : null]}
+        >
+          <Text style={styles.firstColumn}>{index === 0 ? '스터디 팀원' : item.nickname}</Text>
+          <Text style={styles.secondColumn}>{index === 0 ? '출석률' : item.attendance}</Text>
+          <Text style={styles.thirdColumn}>{index === 0 ? '미션달성률' : item.missionCompletion}</Text>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: 10,
+    paddingTop: 20,
+  },
+  headerRow: {
+    backgroundColor: '#E5F5FF',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+  },
+  oddRow: {
+    backgroundColor: 'white',
+  },
+  evenRow: {
+    backgroundColor: '#F8F8F8',
+  },
+  cell: {
+    textAlign: 'center',
+    flex: 1,
+  },
+  firstColumn: {
+    width: 166,
+    textAlign: 'center',
+    color: 'black',
+    fontWeight: 'bold',
+    fontSize: 14,
+    fontFamily: 'PretendardVariable',
+  },
+  secondColumn: {
+    width: 70,
+    textAlign: 'center',
+    color: 'black',
+    fontWeight: 'bold',
+    fontSize: 14,
+    fontFamily: 'PretendardVariable',
+  },
+  thirdColumn: {
+    width: 84,
+    textAlign: 'center',
+    color: 'black',
+    fontWeight: 'bold',
+    fontSize: 14,
+    fontFamily: 'PretendardVariable',
+  },
+});
+
+export default StudyStatusTable;

--- a/SUITE/src/navigation/RootNavigator.tsx
+++ b/SUITE/src/navigation/RootNavigator.tsx
@@ -22,5 +22,5 @@ export default function RootNavigator() {
     };
     getTokenFromAsyncStorage();
   }, []);
-  return <NavigationContainer>{!token || token.length < 10 ? <AuthStack /> : <AppStack />}</NavigationContainer>;
+  return <NavigationContainer>{!token || token.length < 10 ? <AppStack /> : <AppStack />}</NavigationContainer>;
 }

--- a/SUITE/src/screens/SuiteRoom/SuiteRoomDashboard.tsx
+++ b/SUITE/src/screens/SuiteRoom/SuiteRoomDashboard.tsx
@@ -1,17 +1,75 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, Dimensions } from 'react-native';
+import { View, Text, ScrollView } from 'react-native';
 import { useRecoilValue } from 'recoil';
 import { suiteRoomIdState } from '../../../recoil/atoms';
 import SuiteRoomStyleSheet from '../../style/SuiteRoom';
-import { Header } from '../../hook/header';
-
+import ProgressCircle from 'react-native-progress-circle';
+import StudyStatusTable from '../../hook/studyStatusTable';
 const SuiteRoomDashboard = () => {
   const SuiteRoomId = useRecoilValue(suiteRoomIdState);
+
   return (
-    <View style={SuiteRoomStyleSheet.MyStudyRoomContainer}>
-      <Text>대시보드</Text>
-    </View>
+    <ScrollView style={{ backgroundColor: 'white' }}>
+      <View style={SuiteRoomStyleSheet.MyStudyRoomContainer}>
+        <View style={SuiteRoomStyleSheet.dashBoardContainer}>
+          <View style={SuiteRoomStyleSheet.DepositDayContainer}>
+            <View style={SuiteRoomStyleSheet.DepositBox}>
+              <Text style={SuiteRoomStyleSheet.DepositDayInfoText}>내 환급액</Text>
+              <Text style={SuiteRoomStyleSheet.DepositDayText}>100,000원</Text>
+            </View>
+            <View style={SuiteRoomStyleSheet.DayBox}>
+              <Text style={SuiteRoomStyleSheet.DepositDayInfoText}>체크아웃</Text>
+              <Text style={SuiteRoomStyleSheet.DepositDayText}>D-12</Text>
+            </View>
+          </View>
+          <View style={SuiteRoomStyleSheet.CircleProgressContainer}>
+            <View style={SuiteRoomStyleSheet.AttendanceCircleBox}>
+              <View>
+                <Text style={SuiteRoomStyleSheet.DepositDayInfoText}>내 출석률</Text>
+              </View>
+              <View style={SuiteRoomStyleSheet.AttendanceMissionBox}>
+                <ProgressCircle
+                  percent={80}
+                  radius={65}
+                  borderWidth={45}
+                  color="#4CADA8"
+                  shadowColor="#E2FFFE"
+                  bgColor="white"
+                >
+                  <Text style={SuiteRoomStyleSheet.SuiteRoomDetailCircularBarText}>80%</Text>
+                </ProgressCircle>
+              </View>
+            </View>
+            <View style={SuiteRoomStyleSheet.MissionCircleBox}>
+              <View>
+                <Text style={SuiteRoomStyleSheet.DepositDayInfoText}>내 미션달성률</Text>
+              </View>
+              <View style={SuiteRoomStyleSheet.AttendanceMissionBox}>
+                <ProgressCircle
+                  percent={90}
+                  radius={65}
+                  borderWidth={45}
+                  color="#A38AE7"
+                  shadowColor="#F0EBFF"
+                  bgColor="white"
+                >
+                  <Text style={SuiteRoomStyleSheet.SuiteRoomDetailCircularBarText}>90%</Text>
+                </ProgressCircle>
+              </View>
+            </View>
+          </View>
+          <View style={SuiteRoomStyleSheet.StudyDashboardContainer}>
+            <View style={SuiteRoomStyleSheet.StudyInfoContainer}>
+              <Text style={SuiteRoomStyleSheet.StudyInfoText}>팀 스터디 현황</Text>
+              <Text style={SuiteRoomStyleSheet.DepositText}>보증금 10,000원</Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View style={SuiteRoomStyleSheet.StudyStatusContainer}>
+        <StudyStatusTable />
+      </View>
+    </ScrollView>
   );
 };
-
 export default SuiteRoomDashboard;

--- a/SUITE/src/screens/SuiteRoom/SuiteRoomMyAttendance.tsx
+++ b/SUITE/src/screens/SuiteRoom/SuiteRoomMyAttendance.tsx
@@ -1,13 +1,40 @@
 import React from 'react';
-import { View, Text } from 'react-native';
-import { Header } from '../../hook/header';
+import { View, Text, ScrollView } from 'react-native';
 import SuiteRoomStyleSheet from '../../style/SuiteRoom';
+import { useRecoilValue } from 'recoil';
+import { suiteRoomIdState } from '../../../recoil/atoms';
+import MyAttendanceTable from '../../hook/myAttendanceTable';
+import * as Progress from 'react-native-progress';
 
 const SuiteRoomMyAttendance = () => {
+  const SuiteRoomId = useRecoilValue(suiteRoomIdState);
+
   return (
-    <View style={SuiteRoomStyleSheet.MyStudyRoomContainer}>
-      <Text>내출석</Text>
-    </View>
+    <ScrollView style={{ backgroundColor: 'white' }}>
+      <View style={SuiteRoomStyleSheet.MyStudyRoomContainer}>
+        <View style={SuiteRoomStyleSheet.dashBoardContainer}>
+          <View style={SuiteRoomStyleSheet.AttendanceBoxContainer}>
+            <View style={SuiteRoomStyleSheet.MyattendaceTextContainer}>
+              <Text style={SuiteRoomStyleSheet.MyattendanceText}>내 출석률</Text>
+              <Text style={SuiteRoomStyleSheet.MyAttendanceRate}>80%</Text>
+            </View>
+            <View style={SuiteRoomStyleSheet.MyattendanceProgressBarContainer}>
+              <Progress.Bar progress={0.8} width={288} height={30} color={'#4CADA8'} unfilledColor={'#E2FFFE'} />
+            </View>
+          </View>
+
+          <View style={SuiteRoomStyleSheet.StudyDashboardContainer}>
+            <View style={SuiteRoomStyleSheet.StudyInfoContainer}>
+              <Text style={SuiteRoomStyleSheet.StudyInfoText}>출석 내역</Text>
+              <Text style={SuiteRoomStyleSheet.DepositText}>보증금 10,000원</Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View style={SuiteRoomStyleSheet.StudyStatusContainer}>
+        <MyAttendanceTable />
+      </View>
+    </ScrollView>
   );
 };
 

--- a/SUITE/src/style/SuiteRoom.js
+++ b/SUITE/src/style/SuiteRoom.js
@@ -9,7 +9,6 @@ const SuiteRoomStyleSheet = StyleSheet.create({
   },
   MyStudyRoomContainer: {
     backgroundColor: 'white',
-    height: Height,
   },
   SuiteRoomDetailupperBox: {
     marginLeft: widthPercentage(20),
@@ -192,6 +191,118 @@ const SuiteRoomStyleSheet = StyleSheet.create({
   MySuiteRoomStatusText: {
     width: Dimensions.get('window').width / 4,
     textAlign: 'center',
+  },
+  dashBoardContainer: {
+    flexDirection: 'column',
+    marginTop: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  DepositDayContainer: {
+    flexDirection: 'row',
+  },
+  DepositBox: {
+    width: widthPercentage(160),
+    height: heightPercentage(80),
+    backgroundColor: '#F8F8F8',
+    borderRadius: 5,
+    marginRight: 7,
+  },
+  DepositDayInfoText: {
+    fontSize: 14,
+    fontFamily: 'PretendardVariable',
+    color: 'black',
+    paddingLeft: 20,
+    paddingTop: 10,
+  },
+  DepositDayText: {
+    fontSize: 18,
+    fontFamily: 'PretendardVariable',
+    fontWeight: 'bold',
+    color: 'black',
+    paddingLeft: 20,
+    marginTop: 7,
+  },
+  DayBox: {
+    width: widthPercentage(160),
+    height: heightPercentage(80),
+    backgroundColor: '#F8F8F8',
+    borderRadius: 5,
+  },
+  CircleProgressContainer: {
+    flexDirection: 'row',
+    marginTop: 10,
+  },
+  AttendanceCircleBox: {
+    width: widthPercentage(160),
+    height: heightPercentage(230),
+    backgroundColor: '#F8F8F8',
+    borderRadius: 5,
+    marginRight: 7,
+  },
+  MissionCircleBox: {
+    width: widthPercentage(160),
+    height: heightPercentage(230),
+    backgroundColor: '#F8F8F8',
+    borderRadius: 10,
+  },
+  AttendanceMissionBox: {
+    marginTop: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  StudyDashboardContainer: {
+    marginTop: 32,
+  },
+  StudyInfoContainer: {
+    width: widthPercentage(320),
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  StudyInfoText: {
+    fontWeight: 'bold',
+    color: 'black',
+    fontSize: 16,
+    fontFamily: 'PretendardVariable',
+  },
+  DepositText: {
+    fontSize: 14,
+    color: '#005BA5',
+    fontFamily: 'PretendardVariable',
+  },
+  StudyStatusContainer: {
+    marginBottom: 30,
+  },
+  AttendanceBoxContainer: {
+    backgroundColor: '#F8F8F8',
+    width: widthPercentage(320),
+    height: heightPercentage(110),
+  },
+  MyattendaceTextContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  MyattendanceText: {
+    color: 'black',
+    fontFamily: 'PretendardVariable',
+    fontSize: 14,
+    paddingLeft: 24,
+    paddingTop: 10,
+    fontWeight: 'bold',
+  },
+  MyAttendanceRate: {
+    color: '#050953',
+    fontFamily: 'PretendardVariable',
+    fontSize: 20,
+    paddingRight: 24,
+    paddingTop: 10,
+    fontWeight: 'bold',
+  },
+  MyattendanceProgressBarContainer: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 8,
   },
 });
 


### PR DESCRIPTION
### 🗓️ PR 날짜 🗓️
2023/08/26 


### 🧐 구현 방법 🧐
* 유저가 스위트룸에 들어갔을 때 보이는 대시보드와 현재 출석 보드 UI작성 완료하였습니다.
* 두 페이지 모두 API를 Read하기만 하면 되기 때문에, UI보여주는 부분 가져와서 전시하기만 하면 될 것 같습니다.
* 테이블을 공통으로 만들어서 사용하고 싶었지만, 내용, 크기 모두 달랐기 때문에 두 개의 hook을 만들어서 전시에 사용해주었습니다.
* 칸반보드 UI완성한 후 방장이 스위트룸에 들어갔을 때 보이는 UI구성할 계획입니다. 

### 📸 UI 명세서 사진 📸
![스크린샷 2023-08-26 오후 11 30 05](https://github.com/SWM-TheDreaming/SUITE_FRONT/assets/43203911/5e7c1072-b91b-4636-a6ba-ca6ffb8c8b33)
![스크린샷 2023-08-26 오후 11 30 13](https://github.com/SWM-TheDreaming/SUITE_FRONT/assets/43203911/9bd65591-0b90-4ada-a722-f55cc4121461)

### 실제 코드
