### PR TITLE
SUIT-68-3

### DIFF
--- a/SUITE/src/hook/checkCancelModal.tsx
+++ b/SUITE/src/hook/checkCancelModal.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { View, TouchableOpacity, Text } from 'react-native';
+import mainPageStyleSheet from '../style/style';
+
+interface ModalPopupProps {
+  visible: boolean;
+  onClose: () => void;
+  text: string;
+  onConfirm: () => void;
+}
+
+const CheckCancelModal: React.FC<ModalPopupProps> = ({ visible, onClose, text, onConfirm }) => {
+  if (!visible) {
+    return null;
+  } else
+    return (
+      <View style={{ justifyContent: 'center', alignItems: 'center' }}>
+        <Text style={mainPageStyleSheet.emailChecktext}>{text}</Text>
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+          <TouchableOpacity
+            style={mainPageStyleSheet.CancelButton}
+            onPress={() => {
+              onClose();
+            }}
+          >
+            <Text style={mainPageStyleSheet.SignmodalButtonText}>취소</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={mainPageStyleSheet.CheckButton}
+            onPress={() => {
+              onConfirm();
+            }}
+          >
+            <Text style={mainPageStyleSheet.SignmodalButtonText}>확인</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    );
+};
+
+export default CheckCancelModal;

--- a/SUITE/src/hook/missionList.tsx
+++ b/SUITE/src/hook/missionList.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import AntDesign from 'react-native-vector-icons/AntDesign';
+import ModalPopup from '../hook/modal';
+import CheckCancelModal from '../hook/checkCancelModal';
+
+type DataRow = {
+  id: string;
+  missionName: string;
+  missionDate: string;
+  status: string;
+};
+
+type DataListProps = {
+  data: DataRow[];
+};
+
+const MissionItem: React.FC<DataRow> = ({ id, missionName, missionDate, status }) => {
+  const [visible, setVisible] = useState(false);
+  const [modalText, setModalText] = useState('');
+  const [actionType, setActionType] = useState(null);
+
+  const handleVPress = () => {
+    setModalText('PR을 요청하시겠습니까?');
+    setVisible(true);
+    setActionType('send');
+  };
+
+  const handleXPress = () => {
+    setModalText('PR을 춰소하시겠습니까?');
+    setVisible(true);
+    setActionType('cancel');
+  };
+  const SendPr = () => {
+    console.log('pr날리기');
+    setVisible(false);
+  };
+  const cancelPr = () => {
+    console.log('pr취소하기');
+    setVisible(false);
+  };
+  return (
+    <View style={styles.container}>
+      <View style={{ flexDirection: 'column' }}>
+        <Text style={styles.missionName}>{missionName}</Text>
+        <Text style={styles.missionDate}>{missionDate}</Text>
+      </View>
+      {status == 'progress' ? (
+        <TouchableOpacity onPress={handleVPress} style={styles.buttonStyle}>
+          {status === 'progress' && <AntDesign name="checkcircle" size={28} color="#005BA5" />}
+        </TouchableOpacity>
+      ) : (
+        <TouchableOpacity onPress={handleXPress} style={styles.buttonStyle}>
+          {status === 'request' && <AntDesign name="closecircle" size={28} color="#B8B8B8" />}
+        </TouchableOpacity>
+      )}
+      <ModalPopup visible={visible}>
+        <CheckCancelModal
+          visible={visible}
+          onClose={() => setVisible(false)}
+          text={modalText}
+          onConfirm={() => (actionType === 'send' ? SendPr() : cancelPr())}
+        />
+      </ModalPopup>
+    </View>
+  );
+};
+export default MissionItem;
+const styles = StyleSheet.create({
+  container: {
+    width: 320,
+    height: 90,
+    backgroundColor: 'white',
+    marginBottom: 8,
+    marginTop: 8,
+    borderRadius: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  missionName: {
+    paddingLeft: 20,
+    fontSize: 16,
+    color: 'black',
+    fontWeight: 'bold',
+    fontFamily: 'PretendardVariable',
+  },
+  missionDate: {
+    paddingLeft: 20,
+    marginTop: 5,
+    fontSize: 14,
+    color: '#888888',
+    fontFamily: 'PretendardVariable',
+  },
+  buttonStyle: {
+    paddingRight: 20,
+  },
+});

--- a/SUITE/src/screens/SuiteRoom/SuiteRoomCanbanBoard.tsx
+++ b/SUITE/src/screens/SuiteRoom/SuiteRoomCanbanBoard.tsx
@@ -1,11 +1,92 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, TouchableOpacity, StyleSheet } from 'react-native';
+import { ScrollView } from 'react-native-gesture-handler';
 import { Header } from '../../hook/header';
 import SuiteRoomStyleSheet from '../../style/SuiteRoom';
+import MissionItem from '../../hook/missionList';
+
+type DataRow = {
+  id: string;
+  missionName: string;
+  missionDate: string;
+  status: string;
+};
+
+const ProgressData: DataRow[] = [
+  { id: '0', missionName: '영어 독해', missionDate: '2023-07-15', status: 'progress' },
+  { id: '1', missionName: '단어 외우기', missionDate: '2023-07-16', status: 'progress' },
+  { id: '2', missionName: '영작', missionDate: '2023-07-17', status: 'progress' },
+  { id: '3', missionName: '2장 외워오기', missionDate: '2023-07-18', status: 'progress' },
+  { id: '4', missionName: '2장 연습문제 풀이', missionDate: '2023-07-19', status: 'progress' },
+  { id: '5', missionName: '3장 예습', missionDate: '2023-07-20', status: 'progress' },
+];
+const RequestData: DataRow[] = [{ id: '1', missionName: '단어 외우기', missionDate: '2023-07-16', status: 'request' }];
+const CompleteData: DataRow[] = [
+  { id: '0', missionName: '영어 독해', missionDate: '2023-07-15', status: 'complete' },
+  { id: '2', missionName: '영작', missionDate: '2023-07-17', status: 'complete' },
+  { id: '4', missionName: '2장 연습문제 풀이', missionDate: '2023-07-19', status: 'complete' },
+];
+
 const SuiteRoomCanbanBoard = () => {
+  const [content, setContent] = useState('진행 중');
+  const [data, setData] = useState(ProgressData);
+  const [selectedButton, setSelectedButton] = useState<string | null>(null);
+  const buttons: string[] = ['progress', 'request', 'complete'];
+  const handlePress = (type: string) => {
+    switch (type) {
+      case 'progress':
+        setSelectedButton('progress');
+        setContent('진행 중');
+        setData(ProgressData);
+        break;
+      case 'request':
+        setSelectedButton('request');
+        setContent('승인 대기중');
+        setData(RequestData);
+        break;
+      case 'complete':
+        setSelectedButton('complete');
+        setContent('완료');
+        setData(CompleteData);
+        break;
+    }
+  };
   return (
-    <View style={SuiteRoomStyleSheet.MyStudyRoomContainer}>
-      <Text>칸반보드</Text>
+    <View>
+      <View style={SuiteRoomStyleSheet.ChoiceMissionContainer}>
+        <View style={SuiteRoomStyleSheet.ChoiceMissionBox}>
+          {buttons.map((button) => (
+            <TouchableOpacity
+              key={button}
+              style={[
+                SuiteRoomStyleSheet.MissionButton,
+                selectedButton === button && SuiteRoomStyleSheet.SelectedMissionButton,
+              ]}
+              onPress={() => handlePress(button)}
+            >
+              <Text
+                style={[
+                  SuiteRoomStyleSheet.MissionText,
+                  selectedButton === button && SuiteRoomStyleSheet.SelectedMissionText,
+                ]}
+              >
+                {button === 'progress' ? '진행중' : button === 'request' ? '승인 대기 중' : '완료'}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      </View>
+      <ScrollView style={{ marginBottom: 60 }}>
+        <View style={SuiteRoomStyleSheet.MissionStatusContainer}>
+          <Text style={SuiteRoomStyleSheet.MissionStatusText}>{content}</Text>
+          <Text style={SuiteRoomStyleSheet.MissionLengthText}>{data.length}</Text>
+        </View>
+        <View style={SuiteRoomStyleSheet.MissionContainer}>
+          {data.map((item) => (
+            <MissionItem key={item.id} {...item} />
+          ))}
+        </View>
+      </ScrollView>
     </View>
   );
 };

--- a/SUITE/src/style/SuiteRoom.js
+++ b/SUITE/src/style/SuiteRoom.js
@@ -304,6 +304,74 @@ const SuiteRoomStyleSheet = StyleSheet.create({
     alignItems: 'center',
     marginTop: 8,
   },
+  MissionContainer: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  MissionStatusContainer: {
+    marginTop: 24,
+    marginLeft: 20,
+    marginBottom: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  MissionStatusText: {
+    color: 'black',
+    fontSize: 16,
+    fontWeight: 'bold',
+    fontFamily: 'PretendardVariable',
+  },
+  MissionLengthText: {
+    marginLeft: 5,
+    color: '#00ACCF',
+    fontSize: 16,
+    fontWeight: 'bold',
+    fontFamily: 'PretendardVariable',
+  },
+  ChoiceMissionContainer: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 24,
+  },
+  ChoiceMissionBox: {
+    width: widthPercentage(320),
+    height: heightPercentage(50),
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 16,
+    backgroundColor: 'white',
+    borderRadius: 24,
+  },
+  SelectedMissionButton: {
+    width: widthPercentage(100),
+    height: heightPercentage(35),
+    borderRadius: 24,
+    backgroundColor: '#050953',
+  },
+  MissionButton: {
+    width: widthPercentage(100),
+    height: heightPercentage(35),
+    borderRadius: 24,
+    backgroundColor: 'white',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  SelectedMissionText: {
+    color: 'white',
+    fontWeight: 'bold',
+    fontSize: 16,
+    fontFamily: 'PretendardVariable',
+  },
+  MissionText: {
+    color: '#D8D8D8',
+    fontWeight: 'bold',
+    fontSize: 16,
+    fontFamily: 'PretendardVariable',
+  },
+  MissionScrollView: {
+    height: Height,
+  },
 });
 
 export default SuiteRoomStyleSheet;

--- a/SUITE/src/style/style.js
+++ b/SUITE/src/style/style.js
@@ -808,6 +808,26 @@ const mainPageStyleSheet = StyleSheet.create({
     textAlign: 'center',
     fontWeight: 'bold',
   },
+  CheckButton: {
+    width: widthPercentage(100),
+    height: heightPercentage(40),
+    backgroundColor: '#005BA5',
+    borderRadius: 25,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginVertical: 20,
+    marginLeft: 10,
+  },
+  CancelButton: {
+    width: widthPercentage(100),
+    height: heightPercentage(40),
+    backgroundColor: '#B8B8B8',
+    borderRadius: 25,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginVertical: 20,
+    marginRight: 10,
+  },
 });
 
 export default mainPageStyleSheet;


### PR DESCRIPTION
### 🗓️ PR 날짜 🗓️
2023/08/28 


### 🧐 구현 방법 🧐
* user가 확인할 수 있는 칸반보드를 만들어 주었습니다.
* 진행중, 승인 진행중, 완료 3개의 보드로 바꿔서 각각의 페이지가 라우팅 되는 것이 아니라 눌렀을 때 각각의 데이터가 보일 수 있게 페이지 구성해주었습니다.
* 아래에 둘 경우 깔끔해 보이지 않아 우선은 위로 두었는데 추후에 UX적용해서 아래에 두는것도 괜찮아 보입니다. 

### 📸 UI 명세서 사진 📸

https://github.com/SWM-TheDreaming/SUITE_FRONT/assets/43203911/1663eff8-9c2d-4658-9404-a59390b52100


### 실제 코드
