### PR TITLE
SUIT-15-1

### DIFF
--- a/SUITE/react-native.config.js
+++ b/SUITE/react-native.config.js
@@ -4,4 +4,5 @@ module.exports = {
     android: {},
   },
   assets: ['./assets/fonts/'],
+  API_URL : 'http://semtle.catholic.ac.kr:8085',
 };

--- a/SUITE/src/api/Sign/FindIdApi.tsx
+++ b/SUITE/src/api/Sign/FindIdApi.tsx
@@ -1,0 +1,25 @@
+import { API_URL } from "../../../react-native.config";
+export const FindIdApi = async (phoneNumber: string | null) => {
+    console.log(phoneNumber)
+  try {
+    const response = await fetch(`${API_URL}/member/id`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        phoneNumber: phoneNumber,
+      }),
+    });
+
+    if (response.ok) {
+      const data = await response.json();
+      return data;
+    } else {
+      const data = await response.json();
+      return data
+    }
+  } catch (error) {
+    throw error;
+  }
+};

--- a/SUITE/src/api/Sign/FindPWApi.tsx
+++ b/SUITE/src/api/Sign/FindPWApi.tsx
@@ -1,0 +1,25 @@
+import { API_URL } from "../../../react-native.config";
+export const FindPWApi = async (email: string | null, newPassword : string | null) => {
+  try {
+    const response = await fetch(`${API_URL}/member/id`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        email: email,
+        newPassword : newPassword
+      }),
+    });
+
+    if (response.ok) {
+      const data = await response.json();
+      return data;
+    } else {
+      const data = await response.json();
+      return data
+    }
+  } catch (error) {
+    throw error;
+  }
+};

--- a/SUITE/src/api/Sign/PhoneAuthenticationApi.tsx
+++ b/SUITE/src/api/Sign/PhoneAuthenticationApi.tsx
@@ -1,19 +1,18 @@
 import { API_URL } from "../../../react-native.config";
-export const emailAuthenticationCodeApi = async (email: string | null) => {
+export const PhoneAuthenticationCodeApi = async (phoneNumber: string | null) => {
   try {
-    const response = await fetch(`${API_URL}/member/auth/mail`, {
+    const response = await fetch(`${API_URL}/member/send-sms`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        email: email,
+        phoneNumber: phoneNumber,
       }),
     });
-
     if (response.ok) {
       const data = await response.json();
-      return data.data.code;
+      return data.data;
     } else {
       const data = await response.json();
       throw new Error(data);

--- a/SUITE/src/api/Sign/sendProfileImageApi.tsx
+++ b/SUITE/src/api/Sign/sendProfileImageApi.tsx
@@ -1,0 +1,25 @@
+import { API_URL } from "../../../react-native.config";
+export const sendProfileImageApi = async (memberId: number | null, imageUrl : string|null) => {
+    console.log(memberId,imageUrl)
+    
+    try {
+        let formData = new FormData();
+        formData.append('file', imageUrl);
+    
+        const response = await fetch(`${API_URL}/member/profile-image/${memberId}`, {
+          method: 'POST',
+          body: formData,
+        });
+    
+        if (response.ok) {
+          const data = await response.json();
+          console.log(data)
+          return data.data;
+        } else {
+          const data = await response.json();
+          throw new Error(data);
+        }
+      } catch (error) {
+        throw error;
+      }
+    };

--- a/SUITE/src/api/Sign/signup.ts
+++ b/SUITE/src/api/Sign/signup.ts
@@ -1,3 +1,5 @@
+import { API_URL } from "../../../react-native.config";
+
 export const signUpAPI = async ({
   email,
   password,
@@ -20,7 +22,7 @@ export const signUpAPI = async ({
   isOauth: boolean;
 }): Promise<void> => {
   try {
-    const response = await fetch('http://semtle.catholic.ac.kr:8085/member/signup', {
+    const response = await fetch(`${API_URL}/member/signup`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -41,7 +43,7 @@ export const signUpAPI = async ({
 
     if (response.ok) {
       const data = await response.json();
-      console.log(data);
+      return data.data.memberId
     } else {
       console.log('Error occurred:', response);
     }

--- a/SUITE/src/navigation/AuthStack.tsx
+++ b/SUITE/src/navigation/AuthStack.tsx
@@ -10,6 +10,7 @@ import UserInformation from '../screens/AuthScreen/SignUp/UserInformation';
 import AuthenticateCode from '../screens/AuthScreen/SignUp/AuthenticateCode';
 import SignUp from '../screens/AuthScreen/SignUp/SignUp';
 import OauthTermOfUse from '../screens/AuthScreen/SignUp/OauthTermOfUse';
+import PhoneAuthentication from '../screens/AuthScreen/SignUp/PhoneAuthetication';
 const Auth = createStackNavigator();
 
 export function AuthStack() {
@@ -42,6 +43,14 @@ export function AuthStack() {
       <Auth.Screen
         name="EmailAuthentication"
         component={EmailAuthentication}
+        options={{
+          headerShown: false,
+          ...TransitionPresets.RevealFromBottomAndroid,
+        }}
+      />
+      <Auth.Screen
+        name="PhoneAuthentication"
+        component={PhoneAuthentication}
         options={{
           headerShown: false,
           ...TransitionPresets.RevealFromBottomAndroid,

--- a/SUITE/src/navigation/AuthStack.tsx
+++ b/SUITE/src/navigation/AuthStack.tsx
@@ -12,6 +12,8 @@ import SignUp from '../screens/AuthScreen/SignUp/SignUp';
 import OauthTermOfUse from '../screens/AuthScreen/SignUp/OauthTermOfUse';
 import PhoneAuthentication from '../screens/AuthScreen/SignUp/PhoneAuthetication';
 import FindId from '../screens/AuthScreen/FindId/FindId';
+import FindPW from '../screens/AuthScreen/FindId/FindPW';
+import NewPW from '../screens/AuthScreen/FindId/NewPW';
 const Auth = createStackNavigator();
 
 export function AuthStack() {
@@ -100,6 +102,22 @@ export function AuthStack() {
       <Auth.Screen
         name="FindId"
         component={FindId}
+        options={{
+          headerShown: false,
+          ...TransitionPresets.RevealFromBottomAndroid,
+        }}
+      />
+      <Auth.Screen
+        name="FindPW"
+        component={FindPW}
+        options={{
+          headerShown: false,
+          ...TransitionPresets.RevealFromBottomAndroid,
+        }}
+      />
+      <Auth.Screen
+        name="NewPW"
+        component={NewPW}
         options={{
           headerShown: false,
           ...TransitionPresets.RevealFromBottomAndroid,

--- a/SUITE/src/navigation/AuthStack.tsx
+++ b/SUITE/src/navigation/AuthStack.tsx
@@ -11,6 +11,7 @@ import AuthenticateCode from '../screens/AuthScreen/SignUp/AuthenticateCode';
 import SignUp from '../screens/AuthScreen/SignUp/SignUp';
 import OauthTermOfUse from '../screens/AuthScreen/SignUp/OauthTermOfUse';
 import PhoneAuthentication from '../screens/AuthScreen/SignUp/PhoneAuthetication';
+import FindId from '../screens/AuthScreen/FindId/FindId';
 const Auth = createStackNavigator();
 
 export function AuthStack() {
@@ -91,6 +92,14 @@ export function AuthStack() {
       <Auth.Screen
         name="SignUp"
         component={SignUp}
+        options={{
+          headerShown: false,
+          ...TransitionPresets.RevealFromBottomAndroid,
+        }}
+      />
+      <Auth.Screen
+        name="FindId"
+        component={FindId}
         options={{
           headerShown: false,
           ...TransitionPresets.RevealFromBottomAndroid,

--- a/SUITE/src/navigation/RootNavigator.tsx
+++ b/SUITE/src/navigation/RootNavigator.tsx
@@ -22,5 +22,5 @@ export default function RootNavigator() {
     };
     getTokenFromAsyncStorage();
   }, []);
-  return <NavigationContainer>{!token || token.length < 10 ? <AppStack /> : <AppStack />}</NavigationContainer>;
+  return <NavigationContainer>{!token || token.length < 10 ? <AuthStack /> : <AppStack />}</NavigationContainer>;
 }

--- a/SUITE/src/screens/AuthScreen/FindId/FindId.tsx
+++ b/SUITE/src/screens/AuthScreen/FindId/FindId.tsx
@@ -6,45 +6,39 @@ import { useNavigation } from '@react-navigation/core';
 import { RootStackNavigationProp } from '../Login';
 import useForm from '../../../hook/useForm';
 import InputField from '../../../components/presents/InputField';
-import { useRecoilState } from 'recoil';
-import { phoneState } from '../../../../recoil/atoms';
-import { PhoneAuthenticationCodeApi } from '../../../api/Sign/PhoneAuthenticationApi';
+import { FindIdApi } from '../../../api/Sign/FindIdApi';
 const FindId = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
   const signUp = useForm();
-  const [isButtonDisabled, setIsButtonDisabled] = useState(true);
   const [phonAuthenticationButtonDisabled, setPhonAuthenticationButtonDisabled] = useState(true)
-  const [phone, setPhone] = useRecoilState(phoneState);
-  const [authenticationCode, setauthenticationCode] = useState('aa');
-  const [verifyCode, setverifyCode] = useState('aa');
+  const [userEmail, setUserEmail] = useState('');
+  const [infoText, setInfoText] = useState('')
   const [isViewDisabled, setIsViewDisabled] = useState(true);
 
   const getPhoneAuthenticationCode = async () => {
     try {
-      const code = await PhoneAuthenticationCodeApi(signUp.getTextInputProps('phone').value);
-      console.log(code)
-      setverifyCode(code);
+      const code = await FindIdApi(signUp.getTextInputProps('phone').value);
+      if (code.statusCode == 200){
+        setInfoText('이메일 정보는 아래와 같습니다')
+        setUserEmail(code.data.email);
+      }
+      else{
+          setInfoText('가입한 이메일 내력이 존재하지 않습니다.')
+          setUserEmail('')
+      }
     } catch (error) {
       console.log('Error occurred:', error);
     }
   };
 
-  const handleAuthencticationCodeChange = (text: string) => {
-    setauthenticationCode(text);
-  };
+ 
   const handleSendButtonPress = () =>{
     getPhoneAuthenticationCode()
     setIsViewDisabled(false)
   }
 
   const handleButtonPress = () => {
-    const phoneValue = signUp.getTextInputProps('phone').value;
-    setPhone(phoneValue);
-    navigation.navigate('UserInformation');
-  };
-
-  const validateCode = () => {
-    return verifyCode === authenticationCode;
+    navigation.navigate('Login');
   };
 
   useEffect(() => {
@@ -58,14 +52,6 @@ const FindId = () => {
   }, [
     signUp.errors.phone,
   ]);
-    useEffect(()=>{
-        if (authenticationCode === verifyCode){
-            setIsButtonDisabled(false)
-        }
-        else{
-            setIsButtonDisabled(true)
-        }
-    },[authenticationCode])
 
   return (
     <View style={mainPageStyleSheet.categoryPageContainer}>
@@ -73,12 +59,12 @@ const FindId = () => {
         <TouchableOpacity
           style={mainPageStyleSheet.pageBackIcon}
           onPress={() => {
-            navigation.navigate('TermOfUse');
+            navigation.navigate('Login');
           }}
         >
           <Icon name="chevron-back" size={24} color={'#000000'} />
         </TouchableOpacity>
-        <Text style={mainPageStyleSheet.SignUpText}>전화번호 인증</Text>
+        <Text style={mainPageStyleSheet.SignUpText}>아이디 찾기</Text>
       </View>
       <View style={mainPageStyleSheet.emailAuthenticationContainer}>
         <Text style={mainPageStyleSheet.idpwtext}>전화번호</Text>
@@ -95,33 +81,29 @@ const FindId = () => {
                     disabled={phonAuthenticationButtonDisabled}
                     onPress = {() =>{handleSendButtonPress()}}
                 >
-                    <Text style={mainPageStyleSheet.phonAuthenticateCodeText}>인증번호 발송</Text>
+                    <Text style={mainPageStyleSheet.phonAuthenticateCodeText}>입력 완료</Text>
                 </TouchableOpacity>
             </View>
         </View>
         <Text>{<Text style={mainPageStyleSheet.idPwInputErrorText}>{signUp.errors.phone}</Text>}</Text>
         { isViewDisabled == false ?
-        <View>
-        <Text style={mainPageStyleSheet.idpwtext}>인증코드</Text>
-            <InputField
-            autoFocus
-            placeholder="인증코드를 입력해주세요"
-            onChangeText={handleAuthencticationCodeChange}
-            />
-            {!validateCode() && <Text style={mainPageStyleSheet.idPwInputErrorText}>코드가 일치하지 않습니다.</Text>}
+        <View >
+        <Text style={mainPageStyleSheet.findEmailText}>{infoText}</Text>
+            <View style={mainPageStyleSheet.findIdContainer}>
+                <Text>{userEmail}</Text>
+            </View>
         </View>
         :null
         }
         </View>
       <View style={mainPageStyleSheet.SignUpNextBtnContainer}>
         <TouchableOpacity
-          style={[mainPageStyleSheet.SignUpNextBtnBtn, isButtonDisabled && mainPageStyleSheet.disabledSignUpNextBtnBtn]}
-          disabled={isButtonDisabled}
+          style={mainPageStyleSheet.SignUpNextBtnBtn}
           onPress={() => {
             handleButtonPress();
           }}
         >
-          <Text style={mainPageStyleSheet.SignUpNextBtnText}>다음</Text>
+          <Text style={mainPageStyleSheet.SignUpNextBtnText}>홈 화면으로 이동</Text>
         </TouchableOpacity>
       </View>
     </View>

--- a/SUITE/src/screens/AuthScreen/FindId/FindId.tsx
+++ b/SUITE/src/screens/AuthScreen/FindId/FindId.tsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import mainPageStyleSheet from '../../../style/style';
+import Icon from 'react-native-vector-icons/Ionicons';
+import { useNavigation } from '@react-navigation/core';
+import { RootStackNavigationProp } from '../Login';
+import useForm from '../../../hook/useForm';
+import InputField from '../../../components/presents/InputField';
+import { useRecoilState } from 'recoil';
+import { phoneState } from '../../../../recoil/atoms';
+import { PhoneAuthenticationCodeApi } from '../../../api/Sign/PhoneAuthenticationApi';
+const FindId = () => {
+  const navigation = useNavigation<RootStackNavigationProp>();
+  const signUp = useForm();
+  const [isButtonDisabled, setIsButtonDisabled] = useState(true);
+  const [phonAuthenticationButtonDisabled, setPhonAuthenticationButtonDisabled] = useState(true)
+  const [phone, setPhone] = useRecoilState(phoneState);
+  const [authenticationCode, setauthenticationCode] = useState('aa');
+  const [verifyCode, setverifyCode] = useState('aa');
+  const [isViewDisabled, setIsViewDisabled] = useState(true);
+
+  const getPhoneAuthenticationCode = async () => {
+    try {
+      const code = await PhoneAuthenticationCodeApi(signUp.getTextInputProps('phone').value);
+      console.log(code)
+      setverifyCode(code);
+    } catch (error) {
+      console.log('Error occurred:', error);
+    }
+  };
+
+  const handleAuthencticationCodeChange = (text: string) => {
+    setauthenticationCode(text);
+  };
+  const handleSendButtonPress = () =>{
+    getPhoneAuthenticationCode()
+    setIsViewDisabled(false)
+  }
+
+  const handleButtonPress = () => {
+    const phoneValue = signUp.getTextInputProps('phone').value;
+    setPhone(phoneValue);
+    navigation.navigate('UserInformation');
+  };
+
+  const validateCode = () => {
+    return verifyCode === authenticationCode;
+  };
+
+  useEffect(() => {
+    if (
+      signUp.errors.phone == '' 
+    ) {
+        setPhonAuthenticationButtonDisabled(false);
+    } else {
+        setPhonAuthenticationButtonDisabled(true);
+    }
+  }, [
+    signUp.errors.phone,
+  ]);
+    useEffect(()=>{
+        if (authenticationCode === verifyCode){
+            setIsButtonDisabled(false)
+        }
+        else{
+            setIsButtonDisabled(true)
+        }
+    },[authenticationCode])
+
+  return (
+    <View style={mainPageStyleSheet.categoryPageContainer}>
+      <View style={mainPageStyleSheet.underStatusBar}>
+        <TouchableOpacity
+          style={mainPageStyleSheet.pageBackIcon}
+          onPress={() => {
+            navigation.navigate('TermOfUse');
+          }}
+        >
+          <Icon name="chevron-back" size={24} color={'#000000'} />
+        </TouchableOpacity>
+        <Text style={mainPageStyleSheet.SignUpText}>전화번호 인증</Text>
+      </View>
+      <View style={mainPageStyleSheet.emailAuthenticationContainer}>
+        <Text style={mainPageStyleSheet.idpwtext}>전화번호</Text>
+        <View style={{flexDirection : 'row'}}>
+            <InputField
+                style={mainPageStyleSheet.phoneNumInputBox}
+                placeholder=" 전화번호 입력해주세요"
+                {...signUp.getTextInputProps('phone')}
+                touched={signUp.touched.phone}
+            />
+            <View style={mainPageStyleSheet.phoneAuthenticateCodeContainer}>
+                <TouchableOpacity 
+                    style={[mainPageStyleSheet.phoneAuthenticateCodeButtonNotDisabled, phonAuthenticationButtonDisabled && mainPageStyleSheet.phoneAuthenticateCodeButton]} 
+                    disabled={phonAuthenticationButtonDisabled}
+                    onPress = {() =>{handleSendButtonPress()}}
+                >
+                    <Text style={mainPageStyleSheet.phonAuthenticateCodeText}>인증번호 발송</Text>
+                </TouchableOpacity>
+            </View>
+        </View>
+        <Text>{<Text style={mainPageStyleSheet.idPwInputErrorText}>{signUp.errors.phone}</Text>}</Text>
+        { isViewDisabled == false ?
+        <View>
+        <Text style={mainPageStyleSheet.idpwtext}>인증코드</Text>
+            <InputField
+            autoFocus
+            placeholder="인증코드를 입력해주세요"
+            onChangeText={handleAuthencticationCodeChange}
+            />
+            {!validateCode() && <Text style={mainPageStyleSheet.idPwInputErrorText}>코드가 일치하지 않습니다.</Text>}
+        </View>
+        :null
+        }
+        </View>
+      <View style={mainPageStyleSheet.SignUpNextBtnContainer}>
+        <TouchableOpacity
+          style={[mainPageStyleSheet.SignUpNextBtnBtn, isButtonDisabled && mainPageStyleSheet.disabledSignUpNextBtnBtn]}
+          disabled={isButtonDisabled}
+          onPress={() => {
+            handleButtonPress();
+          }}
+        >
+          <Text style={mainPageStyleSheet.SignUpNextBtnText}>다음</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+};
+
+export default FindId;

--- a/SUITE/src/screens/AuthScreen/FindId/FindPW.tsx
+++ b/SUITE/src/screens/AuthScreen/FindId/FindPW.tsx
@@ -1,0 +1,114 @@
+import { useNavigation } from '@react-navigation/native';
+import React, { useEffect, useState } from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import useForm from '../../../hook/useForm';
+import mainPageStyleSheet from '../../../style/style';
+import { RootStackNavigationProp } from '../Login';
+import Icon from 'react-native-vector-icons/Ionicons';
+import InputField from '../../../components/presents/InputField';
+import { useRecoilState } from 'recoil';
+import { emailState } from '../../../../recoil/atoms'; // Recoil 상태를 정의한 파일 임포트
+import { emailAuthenticationCodeApi } from '../../../api/Sign/emailAutheticationCode';
+const FindPW = () => {
+  const navigation = useNavigation<RootStackNavigationProp>();
+  const emailAuthentication = useForm();
+  const [isButtonDisabled, setIsButtonDisabled] = useState(true);
+  const [verifyCode, setVerifyCode] = useState('aa')
+  const [visible, setVisible] = useState(false);
+  const [phonAuthenticationButtonDisabled, setPhonAuthenticationButtonDisabled] = useState(true)
+  const [authenticationCode, setauthenticationCode] = useState('');
+  const [email, setEmail] = useRecoilState(emailState);
+
+  const handleSendButtonPress = async () =>{
+    setVisible(true)
+    const code = await emailAuthenticationCodeApi(emailAuthentication.getTextInputProps('username').value);
+    console.log(code)
+    setVerifyCode(code)
+  }
+  const handleAuthencticationCodeChange = (text: string) => {
+    setauthenticationCode(text);
+  };
+  const validateCode = () => {
+    return verifyCode === authenticationCode;
+  };
+  const handleButtonPress = () => {
+    setEmail(emailAuthentication.getTextInputProps('username').value)
+    navigation.navigate('NewPW')
+  };
+
+  useEffect(() => {
+    if (emailAuthentication.errors.username == '') {
+        setPhonAuthenticationButtonDisabled(false);
+    } else {
+        setPhonAuthenticationButtonDisabled(true);
+    }
+  }, [emailAuthentication.errors.username]);
+  useEffect(() => {
+    if (!validateCode()) {
+      setIsButtonDisabled(true);
+    } else {
+      setIsButtonDisabled(false);
+    }
+  }, [validateCode]);
+  return (
+    <View style={mainPageStyleSheet.categoryPageContainer}>
+      <View style={mainPageStyleSheet.underStatusBar}>
+        <TouchableOpacity
+          style={mainPageStyleSheet.pageBackIcon}
+          onPress={() => {
+            navigation.navigate('Login');
+          }}
+        >
+          <Icon name="chevron-back" size={24} color={'#000000'} />
+        </TouchableOpacity>
+        <Text style={mainPageStyleSheet.SignUpText}>비밀번호 찾기</Text>
+      </View>
+      <View style={mainPageStyleSheet.emailAuthenticationContainer}>
+        <Text style={mainPageStyleSheet.idpwtext}>이메일</Text>
+        <View style={{flexDirection : 'row'}}>
+        <InputField
+            style = {mainPageStyleSheet.phoneNumInputBox}
+          placeholder=" 이메일을 입력해주세요"
+          {...emailAuthentication.getTextInputProps('username')}
+          touched={emailAuthentication.touched.username}
+        />
+         <View style={mainPageStyleSheet.phoneAuthenticateCodeContainer}>
+                <TouchableOpacity 
+                    style={[mainPageStyleSheet.phoneAuthenticateCodeButtonNotDisabled, phonAuthenticationButtonDisabled && mainPageStyleSheet.phoneAuthenticateCodeButton]} 
+                    disabled={phonAuthenticationButtonDisabled}
+                    onPress = {() =>{handleSendButtonPress()}}
+                >
+                    <Text style={mainPageStyleSheet.phonAuthenticateCodeText}>인증번호 발송</Text>
+                </TouchableOpacity>
+            </View>
+        </View>
+        <Text style={mainPageStyleSheet.idPwInputErrorText}>{emailAuthentication.errors.username}</Text>
+        
+      </View>
+      {visible === true ?
+      <View style={mainPageStyleSheet.FindPwemailAuthenticationContainer}>
+        <Text style={mainPageStyleSheet.idpwtext}>인증코드</Text>
+        <InputField
+          autoFocus
+          placeholder="인증코드를 입력해주세요"
+          onChangeText={handleAuthencticationCodeChange}
+        />
+        {!validateCode() && <Text style={mainPageStyleSheet.idPwInputErrorText}>코드가 일치하지 않습니다.</Text>}
+      </View>
+    : null}
+      <View style={mainPageStyleSheet.SignUpNextBtnContainer}>
+        <TouchableOpacity
+          style={[mainPageStyleSheet.SignUpNextBtnBtn, isButtonDisabled && mainPageStyleSheet.disabledSignUpNextBtnBtn]}
+          disabled={isButtonDisabled}
+          onPress={() => {
+            handleButtonPress();
+          }}
+        >
+          <Text style={mainPageStyleSheet.SignUpNextBtnText}>다음</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+};
+
+export default FindPW;

--- a/SUITE/src/screens/AuthScreen/FindId/NewPW.tsx
+++ b/SUITE/src/screens/AuthScreen/FindId/NewPW.tsx
@@ -1,0 +1,108 @@
+import { useNavigation } from '@react-navigation/native';
+import React, { useEffect, useState } from 'react';
+import {View, Text, TouchableOpacity } from 'react-native';
+import useForm from '../../../hook/useForm';
+import mainPageStyleSheet from '../../../style/style';
+import { RootStackNavigationProp } from '../Login';
+import Icon from 'react-native-vector-icons/Ionicons';
+import InputField from '../../../components/presents/InputField';
+import { useRecoilState } from 'recoil';
+import { emailState } from '../../../../recoil/atoms'; // Recoil 상태를 정의한 파일 임포트
+import ModalPopup from '../../../hook/modal';
+import SignModalPopup from '../../../components/presents/SignmodalPopup';
+import { FindPWApi } from '../../../api/Sign/FindPWApi';
+const NewPW = () => {
+  const navigation = useNavigation<RootStackNavigationProp>();
+  const emailAuthentication = useForm();
+  const [passwordConfirmation, setPasswordConfirmation] = useState('');
+  const [isButtonDisabled, setIsButtonDisabled] = useState(true);
+  const [email, setEmail] = useRecoilState(emailState);
+  const [visible, setVisible] = useState(false);
+
+  const handlePasswordConfirmationChange = (text: string) => {
+    setPasswordConfirmation(text);
+  };
+  const closeModalAction = () =>{
+      setVisible(false)
+      navigation.navigate('Login')
+  }
+
+  const validatePassword = () => {
+    return emailAuthentication.getTextInputProps('password').value === passwordConfirmation;
+  };
+  const handleButtonPress = () => {
+    const emailValue = emailAuthentication.getTextInputProps('username').value;
+    const passWordValue = emailAuthentication.getTextInputProps('password').value;
+    FindPWApi(emailValue,passWordValue)
+    setVisible(true)
+  };
+
+  useEffect(() => {
+    if (emailAuthentication.errors.password == '' && validatePassword()) {
+      setIsButtonDisabled(false);
+    } else {
+      setIsButtonDisabled(true);
+    }
+  }, [emailAuthentication.errors.password, validatePassword]);
+
+  return (
+    <View style={mainPageStyleSheet.categoryPageContainer}>
+      <View style={mainPageStyleSheet.underStatusBar}>
+        <TouchableOpacity
+          style={mainPageStyleSheet.pageBackIcon}
+          onPress={() => {
+            navigation.navigate('Login');
+          }}
+        >
+          <Icon name="chevron-back" size={24} color={'#000000'} />
+        </TouchableOpacity>
+        <Text style={mainPageStyleSheet.SignUpText}>비밀번호 변경</Text>
+      </View>
+      <View style={mainPageStyleSheet.emailAuthenticationContainer}>
+        <Text style={mainPageStyleSheet.idpwtext}>이메일</Text>
+            <View style={mainPageStyleSheet.depositCheckBox}>
+            <Text>{email}</Text>
+            </View>
+        <Text style={mainPageStyleSheet.idPwInputErrorText}>{emailAuthentication.errors.username}</Text>
+        <Text style={mainPageStyleSheet.idpwtext}>새로운 비밀번호</Text>
+        <InputField
+          style={mainPageStyleSheet.idpwInputBox}
+          placeholder=" 새로운 비밀번호를 입력해주세요"
+          {...emailAuthentication.getTextInputProps('password')}
+          touched={emailAuthentication.touched.password}
+          secureTextEntry
+        />
+        <Text>{<Text style={mainPageStyleSheet.idPwInputErrorText}>{emailAuthentication.errors.password}</Text>}</Text>
+        <Text style={mainPageStyleSheet.idpwtext}>비밀번호 재입력</Text>
+        <InputField
+          style={mainPageStyleSheet.idpwInputBox}
+          placeholder=" 비밀번호를 다시 입력해주세요"
+          onChangeText={handlePasswordConfirmationChange}
+          touched={emailAuthentication.touched.password}
+          secureTextEntry
+        />
+        {!validatePassword() && (
+          <Text style={mainPageStyleSheet.idPwInputErrorText}>비밀번호가 일치하지 않습니다.</Text>
+        )}
+      </View>
+
+      <ModalPopup visible={visible}>
+        <SignModalPopup visible={visible} onClose={() => closeModalAction()} text={'비밀번호 변경이 완료되었습니다'} />
+      </ModalPopup>
+
+      <View style={mainPageStyleSheet.SignUpNextBtnContainer}>
+        <TouchableOpacity
+          style={[mainPageStyleSheet.SignUpNextBtnBtn, isButtonDisabled && mainPageStyleSheet.disabledSignUpNextBtnBtn]}
+          disabled={isButtonDisabled}
+          onPress={() => {
+            handleButtonPress();
+          }}
+        >
+          <Text style={mainPageStyleSheet.SignUpNextBtnText}>다음</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+};
+
+export default NewPW;

--- a/SUITE/src/screens/AuthScreen/Login.tsx
+++ b/SUITE/src/screens/AuthScreen/Login.tsx
@@ -156,7 +156,7 @@ const Login = () => {
             <Text style={mainPageStyleSheet.authInfoText}>아이디 찾기</Text>
           </TouchableOpacity>
           <Text style={mainPageStyleSheet.authInfobar}> | </Text>
-          <TouchableOpacity>
+          <TouchableOpacity onPress = {() => {navigation.navigate('FindPW')}}>
             <Text style={mainPageStyleSheet.authInfoText}>비밀번호 찾기</Text>
           </TouchableOpacity>
         </View>

--- a/SUITE/src/screens/AuthScreen/Login.tsx
+++ b/SUITE/src/screens/AuthScreen/Login.tsx
@@ -152,7 +152,7 @@ const Login = () => {
             </Text>
           </TouchableOpacity>
           <Text style={mainPageStyleSheet.authInfobar}> | </Text>
-          <TouchableOpacity>
+          <TouchableOpacity onPress = {() => {navigation.navigate('FindId')}}>
             <Text style={mainPageStyleSheet.authInfoText}>아이디 찾기</Text>
           </TouchableOpacity>
           <Text style={mainPageStyleSheet.authInfobar}> | </Text>

--- a/SUITE/src/screens/AuthScreen/SignUp/AuthenticateCode.tsx
+++ b/SUITE/src/screens/AuthScreen/SignUp/AuthenticateCode.tsx
@@ -24,7 +24,7 @@ const AuthenticateCode = () => {
     return verifyCode === authenticationCode;
   };
   const handleButtonPress = () => {
-    navigation.navigate('UserInformation'); //로그인 API 연동
+    navigation.navigate('PhoneAuthentication'); //로그인 API 연동
   };
   useEffect(() => {
     if (!validateCode()) {
@@ -33,17 +33,17 @@ const AuthenticateCode = () => {
       setIsButtonDisabled(false);
     }
   }, [validateCode]);
-  useEffect(() => {
-    const getEmailCode = async () => {
-      try {
-        const code = await emailAuthenticationCodeApi(email);
-        setverifyCode(code);
-      } catch (error) {
-        console.log('Error occurred:', error);
-      }
-    };
-    getEmailCode();
-  }, []);
+  // useEffect(() => {
+  //   const getEmailCode = async () => {
+  //     try {
+  //       const code = await emailAuthenticationCodeApi(email);
+  //       setverifyCode(code);
+  //     } catch (error) {
+  //       console.log('Error occurred:', error);
+  //     }
+  //   };
+  //   getEmailCode();
+  // }, []);
 
   return (
     <View style={mainPageStyleSheet.categoryPageContainer}>

--- a/SUITE/src/screens/AuthScreen/SignUp/EmailAuthentication.tsx
+++ b/SUITE/src/screens/AuthScreen/SignUp/EmailAuthentication.tsx
@@ -10,7 +10,7 @@ import { useRecoilState } from 'recoil';
 import { emailState, isAuthState, passwordState } from '../../../../recoil/atoms'; // Recoil 상태를 정의한 파일 임포트
 import ModalPopup from '../../../hook/modal';
 import SignModalPopup from '../../../components/presents/SignmodalPopup';
-
+import { API_URL } from '../../../../react-native.config';
 const EmailAuthentication = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
   const emailAuthentication = useForm();
@@ -28,7 +28,7 @@ const EmailAuthentication = () => {
 
   const fetchData = async () => {
     try {
-      const response = await fetch('http://semtle.catholic.ac.kr:8085/member/verification/email', {
+      const response = await fetch(`${API_URL}/member/verification/email`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/SUITE/src/screens/AuthScreen/SignUp/PhoneAuthetication.tsx
+++ b/SUITE/src/screens/AuthScreen/SignUp/PhoneAuthetication.tsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import mainPageStyleSheet from '../../../style/style';
+import Icon from 'react-native-vector-icons/Ionicons';
+import { useNavigation } from '@react-navigation/core';
+import { RootStackNavigationProp } from '../Login';
+import useForm from '../../../hook/useForm';
+import InputField from '../../../components/presents/InputField';
+import { useRecoilState } from 'recoil';
+import { phoneState } from '../../../../recoil/atoms';
+import { PhoneAuthenticationCodeApi } from '../../../api/Sign/PhoneAuthenticationApi';
+const PhoneAuthentication = () => {
+  const navigation = useNavigation<RootStackNavigationProp>();
+  const signUp = useForm();
+  const [isButtonDisabled, setIsButtonDisabled] = useState(true);
+  const [phonAuthenticationButtonDisabled, setPhonAuthenticationButtonDisabled] = useState(true)
+  const [phone, setPhone] = useRecoilState(phoneState);
+  const [authenticationCode, setauthenticationCode] = useState('aa');
+  const [verifyCode, setverifyCode] = useState('aa');
+  const [isViewDisabled, setIsViewDisabled] = useState(true);
+
+  const getPhoneAuthenticationCode = async () => {
+    try {
+      const code = await PhoneAuthenticationCodeApi(signUp.getTextInputProps('phone').value);
+      console.log(code)
+      setverifyCode(code);
+    } catch (error) {
+      console.log('Error occurred:', error);
+    }
+  };
+
+  const handleAuthencticationCodeChange = (text: string) => {
+    setauthenticationCode(text);
+  };
+  const handleSendButtonPress = () =>{
+    getPhoneAuthenticationCode()
+    setIsViewDisabled(false)
+  }
+
+  const handleButtonPress = () => {
+    const phoneValue = signUp.getTextInputProps('phone').value;
+    setPhone(phoneValue);
+    navigation.navigate('UserInformation');
+  };
+
+  const validateCode = () => {
+    return verifyCode === authenticationCode;
+  };
+
+  useEffect(() => {
+    if (
+      signUp.errors.phone == '' 
+    ) {
+        setPhonAuthenticationButtonDisabled(false);
+    } else {
+        setPhonAuthenticationButtonDisabled(true);
+    }
+  }, [
+    signUp.errors.phone,
+  ]);
+    useEffect(()=>{
+        if (authenticationCode === verifyCode){
+            setIsButtonDisabled(false)
+        }
+        else{
+            setIsButtonDisabled(true)
+        }
+    },[authenticationCode])
+
+  return (
+    <View style={mainPageStyleSheet.categoryPageContainer}>
+      <View style={mainPageStyleSheet.underStatusBar}>
+        <TouchableOpacity
+          style={mainPageStyleSheet.pageBackIcon}
+          onPress={() => {
+            navigation.navigate('TermOfUse');
+          }}
+        >
+          <Icon name="chevron-back" size={24} color={'#000000'} />
+        </TouchableOpacity>
+        <Text style={mainPageStyleSheet.SignUpText}>전화번호 인증</Text>
+      </View>
+      <View style={mainPageStyleSheet.emailAuthenticationContainer}>
+        <Text style={mainPageStyleSheet.idpwtext}>전화번호</Text>
+        <View style={{flexDirection : 'row'}}>
+            <InputField
+                style={mainPageStyleSheet.phoneNumInputBox}
+                placeholder=" 전화번호 입력해주세요"
+                {...signUp.getTextInputProps('phone')}
+                touched={signUp.touched.phone}
+            />
+            <View style={mainPageStyleSheet.phoneAuthenticateCodeContainer}>
+                <TouchableOpacity 
+                    style={[mainPageStyleSheet.phoneAuthenticateCodeButtonNotDisabled, phonAuthenticationButtonDisabled && mainPageStyleSheet.phoneAuthenticateCodeButton]} 
+                    disabled={phonAuthenticationButtonDisabled}
+                    onPress = {() =>{handleSendButtonPress()}}
+                >
+                    <Text style={mainPageStyleSheet.phonAuthenticateCodeText}>인증번호 발송</Text>
+                </TouchableOpacity>
+            </View>
+        </View>
+        <Text>{<Text style={mainPageStyleSheet.idPwInputErrorText}>{signUp.errors.phone}</Text>}</Text>
+        { isViewDisabled == false ?
+        <View>
+        <Text style={mainPageStyleSheet.idpwtext}>인증코드</Text>
+            <InputField
+            autoFocus
+            placeholder="인증코드를 입력해주세요"
+            onChangeText={handleAuthencticationCodeChange}
+            />
+            {!validateCode() && <Text style={mainPageStyleSheet.idPwInputErrorText}>코드가 일치하지 않습니다.</Text>}
+        </View>
+        :null
+        }
+        </View>
+      <View style={mainPageStyleSheet.SignUpNextBtnContainer}>
+        <TouchableOpacity
+          style={[mainPageStyleSheet.SignUpNextBtnBtn, isButtonDisabled && mainPageStyleSheet.disabledSignUpNextBtnBtn]}
+          disabled={isButtonDisabled}
+          onPress={() => {
+            handleButtonPress();
+          }}
+        >
+          <Text style={mainPageStyleSheet.SignUpNextBtnText}>다음</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+};
+
+export default PhoneAuthentication;

--- a/SUITE/src/screens/AuthScreen/SignUp/Profile.tsx
+++ b/SUITE/src/screens/AuthScreen/SignUp/Profile.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { sendProfileImageApi } from '../../../api/Sign/sendProfileImageApi';
 import { View, Image, Text } from 'react-native';
 import mainPageStyleSheet from '../../../style/style';
 import {
@@ -35,20 +36,30 @@ const Profile = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
   const profile = useForm();
   const [isButtonDisabled, setIsButtonDisabled] = useState(true);
+  const [memberId, setMemberId] = useState('')
 
-  const handleButtonPress = () => {
-    signUpAPI({
-      email: email,
-      password: password,
-      name: name,
-      nickname: profile.getTextInputProps('nickname').value,
-      phone: phone,
-      securityNum: securityNum,
-      preferStudy: preferStudy,
-      studyMethod: studyMethod,
-      isOauth: isOauth,
+  const getEmailCode = async () => {
+    try {
+      const code = await signUpAPI({
+        email: email,
+        password: password,
+        name: name,
+        nickname: profile.getTextInputProps('nickname').value,
+        phone: phone,
+        securityNum: securityNum,
+        preferStudy: preferStudy,
+        studyMethod: studyMethod,
+        isOauth: isOauth
     });
+    console.log(code)
+    sendProfileImageApi(parseInt(String(code)),img)
     navigation.navigate('SignUp');
+  } catch (error) {
+      console.log('Error occurred:', error);
+    }
+  };
+  const handleButtonPress = () => {
+    getEmailCode()
   };
   function pickImg() {
     launchImageLibrary(

--- a/SUITE/src/screens/AuthScreen/SignUp/UserInformation.tsx
+++ b/SUITE/src/screens/AuthScreen/SignUp/UserInformation.tsx
@@ -9,7 +9,7 @@ import InputField from '../../../components/presents/InputField';
 import { SelectList } from 'react-native-dropdown-select-list';
 import { Category } from '../../../data/Categoty';
 import { useRecoilState } from 'recoil';
-import { nameState, phoneState, preferStudyState, securityNumState, studyMethodState } from '../../../../recoil/atoms';
+import { nameState, preferStudyState, securityNumState, studyMethodState } from '../../../../recoil/atoms';
 import convertStudyValue from '../../../data/ChangeCategory';
 import convertStudyMethod from '../../../data/ChangeStudyMethod';
 const UserInformation = () => {
@@ -19,7 +19,6 @@ const UserInformation = () => {
   const [selectedItem, setSelectedItem] = useState('');
   const [isButtonDisabled, setIsButtonDisabled] = useState(true);
   const [name, setName] = useRecoilState(nameState);
-  const [phone, setPhone] = useRecoilState(phoneState);
   const [securityNum, setsecurityNum] = useRecoilState(securityNumState);
   const [preferStudy, setpreferStudy] = useRecoilState(preferStudyState);
   const [studyMethod, setstudyMethod] = useRecoilState(studyMethodState);
@@ -29,12 +28,10 @@ const UserInformation = () => {
   };
   const handleButtonPress = () => {
     const nameValue = signUp.getTextInputProps('name').value;
-    const phoneValue = signUp.getTextInputProps('phone').value;
     const securityNumValue = signUp.getTextInputProps('birthday').value + '-' + signUp.getTextInputProps('sex').value;
     const preferStudyValue = convertStudyValue(selectedCategory);
     const studyMethodValue = convertStudyMethod(selectedItem);
     setName(nameValue);
-    setPhone(phoneValue);
     setsecurityNum(securityNumValue);
     setpreferStudy(preferStudyValue);
     setstudyMethod(studyMethodValue);
@@ -43,7 +40,6 @@ const UserInformation = () => {
   useEffect(() => {
     if (
       signUp.errors.name == '' &&
-      signUp.errors.phone == '' &&
       selectedItem != '' &&
       selectedCategory != '' &&
       signUp.getTextInputProps('birthday').value != '' &&
@@ -55,14 +51,11 @@ const UserInformation = () => {
     }
   }, [
     signUp.errors.name,
-    signUp.errors.phone,
-    signUp.errors.phone,
     signUp.getTextInputProps('birthday').value,
     signUp.getTextInputProps('sex').value,
     selectedCategory,
     selectedItem,
   ]);
-
   return (
     <View style={mainPageStyleSheet.categoryPageContainer}>
       <View style={mainPageStyleSheet.underStatusBar}>
@@ -86,14 +79,6 @@ const UserInformation = () => {
           touched={signUp.touched.name}
         />
         <Text>{<Text style={mainPageStyleSheet.idPwInputErrorText}>{signUp.errors.name}</Text>}</Text>
-        <Text style={mainPageStyleSheet.idpwtext}>전화번호</Text>
-        <InputField
-          style={mainPageStyleSheet.idpwInputBox}
-          placeholder=" 전화번호 입력해주세요"
-          {...signUp.getTextInputProps('phone')}
-          touched={signUp.touched.phone}
-        />
-        <Text>{<Text style={mainPageStyleSheet.idPwInputErrorText}>{signUp.errors.phone}</Text>}</Text>
         <Text style={mainPageStyleSheet.idpwtext}>주민번호</Text>
         <View style={{ flexDirection: 'row' }}>
           <View style={{ flexDirection: 'column' }}>

--- a/SUITE/src/style/style.js
+++ b/SUITE/src/style/style.js
@@ -549,6 +549,11 @@ const mainPageStyleSheet = StyleSheet.create({
     marginLeft: widthPercentage(24),
     marginRight: widthPercentage(24),
   },
+  FindPwemailAuthenticationContainer: {
+    marginTop: heightPercentage(5),
+    marginLeft: widthPercentage(24),
+    marginRight: widthPercentage(24),
+  },
   securityNumBox: {
     width: widthPercentage(140),
     height: heightPercentage(50),

--- a/SUITE/src/style/style.js
+++ b/SUITE/src/style/style.js
@@ -878,6 +878,22 @@ const mainPageStyleSheet = StyleSheet.create({
     marginVertical: 20,
     marginRight: 10,
   },
+  findIdContainer: {
+    width: widthPercentage(310),
+    height: heightPercentage(50),
+    marginTop: heightPercentage(10),
+    paddingLeft: 13,
+    justifyContent: 'center',
+    alignItems :'center'
+  },
+  findEmailText: {
+    fontSize: 20,
+    color: 'black',
+    fontWeight : 'bold',
+    marginTop: heightPercentage(70),
+    fontFamily: 'PretendardVariable',
+    textAlign : 'center'
+  },
 });
 
 export default mainPageStyleSheet;

--- a/SUITE/src/style/style.js
+++ b/SUITE/src/style/style.js
@@ -307,6 +307,47 @@ const mainPageStyleSheet = StyleSheet.create({
     borderRadius: 3,
     paddingLeft: 13,
   },
+  phoneNumInputBox: {
+    width: widthPercentage(220),
+    height: heightPercentage(50),
+    marginTop: heightPercentage(10),
+    borderColor: '#E8E8E8',
+    borderWidth: 1,
+    borderRadius: 3,
+    paddingLeft: 13,
+  },
+  phoneAuthenticateCodeContainer : {
+    alignItems : 'center',
+    justifyContent : 'center',
+    marginLeft : 10,
+    marginTop: heightPercentage(10),
+  },
+  phoneAuthenticateCodeButton : {
+    borderWidth : 1,
+    borderRadius : 20,
+    borderColor : '#E8E8E8',
+    height : heightPercentage(50), 
+    width : widthPercentage(80),
+    alignItems : 'center',
+    justifyContent : 'center',
+    backgroundColor : '#E8E8E8'
+  },
+  phoneAuthenticateCodeButtonNotDisabled : {
+    borderWidth : 1,
+    borderRadius : 20,
+    borderColor : '#E8E8E8',
+    height : heightPercentage(50), 
+    width : widthPercentage(80),
+    alignItems : 'center',
+    justifyContent : 'center',
+    backgroundColor : '#050953'
+  },
+  phonAuthenticateCodeText : {
+    fontSize : 12,
+    color : 'white',
+    fontWeight : 'bold',
+    fontFamily: 'PretendardVariable',
+  },
   loginButtonContainer: {
     justifyContent: 'center',
     alignItems: 'center',
@@ -580,9 +621,10 @@ const mainPageStyleSheet = StyleSheet.create({
     paddingLeft: 13,
   },
   signUpCompleteText: {
-    fontsize: 10,
+    fontSize: 14,
     color: '#B3ADAD',
     fontFamily: 'PretendardVariable',
+    marginBottom : 10
   },
   emailChecktext: {
     fontSize: 17,

--- a/SUITE/src/types.ts
+++ b/SUITE/src/types.ts
@@ -3,6 +3,7 @@ export type RootStackParamList = {
   TabBarNavigation: undefined;
   ContractTabNavigation : undefined;
   LeaderTabBarNavigation : undefined;
+  PhoneAuthentication : undefined
   CategoryFilter: undefined;
   Studylist: { selectedCategories: string[] };
   Mystudy: undefined;

--- a/SUITE/src/types.ts
+++ b/SUITE/src/types.ts
@@ -16,6 +16,7 @@ export type RootStackParamList = {
   UserInformation: undefined;
   AuthenticateCode: undefined;
   OauthTermOfUse: undefined;
+  FindId : undefined;
   SuiteRoomurl: undefined;
   SuiteRoomInfo: undefined;
   SuiteRoompay: undefined;

--- a/SUITE/src/types.ts
+++ b/SUITE/src/types.ts
@@ -17,6 +17,8 @@ export type RootStackParamList = {
   AuthenticateCode: undefined;
   OauthTermOfUse: undefined;
   FindId : undefined;
+  FindPW : undefined;
+  NewPW : undefined;
   SuiteRoomurl: undefined;
   SuiteRoomInfo: undefined;
   SuiteRoompay: undefined;


### PR DESCRIPTION
### 🗓️ PR 날짜 🗓️
2023/09/01 

### 🧐 구현 방법 🧐
* 회원가입 과정에서 휴대전화 인증 UI 추가해서 회원가입 진행했습니다.
* 마지막에 Signup하는 부분과, profile Image 등록하는 부분 API 분리해서 호출 하였습니다.
* 아이디 찾기 UI 와 API 연동 완료하였고, 과정에서 핸드폰 인증 사용하였습니다.
* 비밀번호 찾기 UI와 API 연동 완료하였고, 과정에서 이메일 인증 사용하였습니다.

### 📸 UI 명세서 사진 📸

https://github.com/SWM-TheDreaming/SUITE_FRONT/assets/43203911/f52e2160-41f5-476c-b2c5-b702974598c0


### 실제 코드
